### PR TITLE
[FEATURE] add create flashcard and support Remnote markdown import to create note/flashcard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,19 +22,21 @@ When changing action names, payloads, or response semantics, validate all three 
 
 ## Contract Map (Current)
 
-### External MCP Tool Surface (7)
+### External MCP Tool Surface (8)
 
 - `remnote_create_note`
+- `remnote_create_note_md`
 - `remnote_search`
 - `remnote_search_by_tag`
 - `remnote_read_note`
 - `remnote_update_note`
 - `remnote_append_journal`
+- `remnote_get_playbook`
 - `remnote_status`
 
 ### Bridge Action Mapping and Compatibility
 
-- Most tools map to same conceptual bridge actions (`create_note`, `search`, `search_by_tag`, `read_note`,
+- Most tools map to same conceptual bridge actions (`create_note`, `create_note_md`, `search`, `search_by_tag`, `read_note`,
   `update_note`, `append_journal`, `get_status`).
 - Bridge plugin sends WebSocket `hello` with plugin version.
 - `remnote_status` enriches output with server version + optional `version_warning` for compatibility drift.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,6 @@ When changing action names, payloads, or response semantics, validate all three 
 ### External MCP Tool Surface (8)
 
 - `remnote_create_note`
-- `remnote_create_note_md`
 - `remnote_search`
 - `remnote_search_by_tag`
 - `remnote_read_note`
@@ -36,7 +35,7 @@ When changing action names, payloads, or response semantics, validate all three 
 
 ### Bridge Action Mapping and Compatibility
 
-- Most tools map to same conceptual bridge actions (`create_note`, `create_note_md`, `search`, `search_by_tag`, `read_note`,
+- Most tools map to same conceptual bridge actions (`create_note`, `search`, `search_by_tag`, `read_note`,
   `update_note`, `append_journal`, `get_status`).
 - Bridge plugin sends WebSocket `hello` with plugin version.
 - `remnote_status` enriches output with server version + optional `version_warning` for compatibility drift.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Enhanced `remnote_create_note` with flashcard support (`backText`, `isConcept`, `isDescriptor`).
+- Added `remnote_create_note_md` tool to allow creating native hierarchical Rem structures (including flashcards via `::`) from indented markdown strings.
+
 ## [0.8.0] - 2026-03-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
-- Enhanced `remnote_create_note` with flashcard support (`backText`, `isConcept`, `isDescriptor`).
-- Added `remnote_create_note_md` tool to allow creating native hierarchical Rem structures (including flashcards via `::`) from indented markdown strings.
+- Enhanced `remnote_create_note` with direct hierarchical tree creation and flashcards via RemNote native markdown syntax.
+
+### Changed
+- Updated `remnote_create_note` input schema:
+  - Made `title` optional (at least one of `title` or `content` must be provided).
+- Updated `remnote_create_note` output schema to return plural `remIds` and `titles` arrays.
 
 ## [0.8.0] - 2026-03-04
 

--- a/docs/guides/tools-reference.md
+++ b/docs/guides/tools-reference.md
@@ -65,7 +65,6 @@ Create a note "Important Meeting" with tags "work" and "urgent"
 **Create a flashcard:**
 ```
 Create a Concept card titled "Photosynthesis" with back text "Process by which plants make food"
-Created a flashcard "<title>" "<backText>"
 ```
 
 ### Response

--- a/docs/guides/tools-reference.md
+++ b/docs/guides/tools-reference.md
@@ -11,7 +11,8 @@ automatically available in any connected MCP client.
 
 | Tool | Description | Use Case |
 |------|-------------|----------|
-| `remnote_create_note` | Create new notes | Adding new knowledge, ideas, references |
+| `remnote_create_note` | Create new notes or flashcards | Adding new knowledge, ideas, references, or flashcards |
+| `remnote_create_note_md` | Create hierarchical markdown trees | Quickly importing bulleted outlines/trees |
 | `remnote_search` | Search knowledge base | Finding existing notes, exploring topics |
 | `remnote_search_by_tag` | Search by tag | Finding ancestor context for tagged notes |
 | `remnote_read_note` | Read note content | Retrieving details, reading hierarchies |
@@ -22,16 +23,19 @@ automatically available in any connected MCP client.
 
 ## remnote_create_note
 
-Create a new note in RemNote with optional parent hierarchy and tags.
+Create a new note/flashcard in RemNote with optional parent hierarchy and tags.
 
 ### Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `title` | string | Yes | The title/name of the note |
+| `title` | string | Yes | The title/name of the note, or the front text of a flashcard |
 | `content` | string | No | Child content as bullet points (newline-separated) |
 | `parentId` | string | No | Parent Rem ID to nest this note under |
 | `tags` | string[] | No | Array of tag names to apply |
+| `backText` | string | No | The back text to create a flashcard |
+| `isConcept` | boolean | No | Explicitly create a Concept card (::) |
+| `isDescriptor`| boolean | No | Explicitly create a Descriptor card (;;) |
 
 ### Usage
 
@@ -58,6 +62,12 @@ Create a note "Chapter 1" under the note with ID abc123
 Create a note "Important Meeting" with tags "work" and "urgent"
 ```
 
+**Create a flashcard:**
+```
+Create a Concept card titled "Photosynthesis" with back text "Process by which plants make food"
+Created a flashcard "<title>" "<backText>"
+```
+
 ### Response
 
 Returns the created note's Rem ID and confirmation:
@@ -66,7 +76,7 @@ Returns the created note's Rem ID and confirmation:
 {
   "remId": "abc123xyz",
   "title": "Project Ideas",
-  "created": true
+  "backText": "Optional back text returned if created as a card"
 }
 ```
 
@@ -76,6 +86,63 @@ Returns the created note's Rem ID and confirmation:
 - Structure content with bullets (`-` or `•`) for RemNote hierarchy
 - Use `parentId` to organize notes within existing hierarchies
 - Tags can be existing or new - new tags are created automatically
+- Provide `backText` to turn the note into a flashcard
+
+## remnote_create_note_md
+
+Create a hierarchical note tree in RemNote from a markdown string (indented bullets). Automatically parses indentations into parent-child Rem relationships using RemNote's native capabilities.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `content` | string | Yes | Markdown text containing the bulleted tree |
+| `title` | string | No | Optional root Rem title to enclose the entire tree. If not provided, parent Rem will be used as the title. |
+| `parentId` | string | No | Parent Rem ID where the tree will be created, if not provided, the tree will be created under defaultParentId under plugin settings. |
+| `tags` | string[] | No | Array of tags to apply to the root/title Rem |
+
+### Usage
+
+**Create from an outline or hierarchical note:**
+```
+Create a markdown tree:
+- Programming Languages
+  - Python
+  - JavaScript
+    - React
+    - Node
+- Databases
+```
+
+**Create flashcards via markdown:**
+Since this uses RemNote's native markdown parser, you can create flashcards inline using `::` for Concept cards and `;;` for Descriptor cards. This function fully supports RemNote's markdown-based flashcard creation.
+
+For example, if you want to batch create flashcards, you can use the following format:
+
+```
+Create a markdown tree of biology terms, titled as "Energy Flow in Biology":
+- Photosynthesis :: Process by which plants make food
+- Cellular Respiration
+  - Definition ;; The process of breaking down glucose for energy
+```
+
+For more usage, refer to https://help.remnote.com/en/articles/9252072-how-to-import-flashcards-from-text#h_fc1588b3b7
+
+### Response
+
+Returns an array of remIds containing the title (if provided) and each generated markdown line, in top-to-bottom order:
+
+```json
+{
+  "remIds": ["abc123xyz", "def456xyz"],
+  "title": "Title of the markdown tree"
+}
+```
+
+### Tips
+
+- Provide a `title` if you want all items nested logically under a single new Rem
+- Use `- ` or `* ` for each bullet and use leading spaces for nesting levels
 
 ## remnote_search
 
@@ -499,6 +566,7 @@ names.
 
 | User says | AI uses |
 |-----------|---------|
+| "Create a note about X" | `remnote_create_note` |
 | "Create a note about X" | `remnote_create_note` |
 | "Search for Y" | `remnote_search` |
 | "Show me note abc123" | `remnote_read_note` |

--- a/docs/guides/tools-reference.md
+++ b/docs/guides/tools-reference.md
@@ -11,8 +11,7 @@ automatically available in any connected MCP client.
 
 | Tool | Description | Use Case |
 |------|-------------|----------|
-| `remnote_create_note` | Create new notes or flashcards | Adding new knowledge, ideas, references, or flashcards |
-| `remnote_create_note_md` | Create hierarchical markdown trees | Quickly importing bulleted outlines/trees |
+| `remnote_create_note` | Create new notes or flashcards | Adding new knowledge, ideas, references, or flashcards. Supports hierarchical markdown and flashcard syntax. |
 | `remnote_search` | Search knowledge base | Finding existing notes, exploring topics |
 | `remnote_search_by_tag` | Search by tag | Finding ancestor context for tagged notes |
 | `remnote_read_note` | Read note content | Retrieving details, reading hierarchies |
@@ -29,13 +28,10 @@ Create a new note/flashcard in RemNote with optional parent hierarchy and tags.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `title` | string | Yes | The title/name of the note, or the front text of a flashcard |
-| `content` | string | No | Child content as bullet points (newline-separated) |
+| `title` | string | No | The title of the note (optional if content is provided) |
+| `content` | string | No | Child content as bullet points or hierarchical markdown |
 | `parentId` | string | No | Parent Rem ID to nest this note under |
 | `tags` | string[] | No | Array of tag names to apply |
-| `backText` | string | No | The back text to create a flashcard |
-| `isConcept` | boolean | No | Explicitly create a Concept card (::) |
-| `isDescriptor`| boolean | No | Explicitly create a Descriptor card (;;) |
 
 ### Usage
 
@@ -64,43 +60,8 @@ Create a note "Important Meeting" with tags "work" and "urgent"
 
 **Create a flashcard:**
 ```
-Create a Concept card titled "Photosynthesis" with back text "Process by which plants make food"
+Create a Concept card titled "Photosynthesis" with content "Photosynthesis :: Process by which plants make food"
 ```
-
-### Response
-
-Returns the created note's Rem ID and confirmation:
-
-```json
-{
-  "remId": "abc123xyz",
-  "title": "Project Ideas",
-  "backText": "Optional back text returned if created as a card"
-}
-```
-
-### Tips
-
-- Use descriptive titles for better searchability
-- Structure content with bullets (`-` or `•`) for RemNote hierarchy
-- Use `parentId` to organize notes within existing hierarchies
-- Tags can be existing or new - new tags are created automatically
-- Provide `backText` to turn the note into a flashcard
-
-## remnote_create_note_md
-
-Create a hierarchical note tree in RemNote from a markdown string (indented bullets). Automatically parses indentations into parent-child Rem relationships using RemNote's native capabilities.
-
-### Parameters
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `content` | string | Yes | Markdown text containing the bulleted tree |
-| `title` | string | No | Optional root Rem title to enclose the entire tree. If not provided, parent Rem will be used as the title. |
-| `parentId` | string | No | Parent Rem ID where the tree will be created, if not provided, the tree will be created under defaultParentId under plugin settings. |
-| `tags` | string[] | No | Array of tags to apply to the root/title Rem |
-
-### Usage
 
 **Create from an outline or hierarchical note:**
 ```
@@ -127,21 +88,23 @@ Create a markdown tree of biology terms, titled as "Energy Flow in Biology":
 
 For more usage, refer to https://help.remnote.com/en/articles/9252072-how-to-import-flashcards-from-text#h_fc1588b3b7
 
-### Response
-
-Returns an array of remIds containing the title (if provided) and each generated markdown line, in top-to-bottom order:
+Returns an array of remIds containing the title (if provided) and each generated markdown line:
 
 ```json
 {
   "remIds": ["abc123xyz", "def456xyz"],
-  "title": "Title of the markdown tree"
+  "titles": ["Project Ideas", "Child 1"]
 }
 ```
 
 ### Tips
 
-- Provide a `title` if you want all items nested logically under a single new Rem
-- Use `- ` or `* ` for each bullet and use leading spaces for nesting levels
+- Use descriptive titles for better searchability
+- Structure content with bullets (`-` or `•`) for RemNote hierarchy
+- Use `parentId` to organize notes within existing hierarchies
+- Tags can be existing or new - new tags are created automatically
+- Provide `backText` to turn the note into a flashcard
+
 
 ## remnote_search
 
@@ -565,7 +528,6 @@ names.
 
 | User says | AI uses |
 |-----------|---------|
-| "Create a note about X" | `remnote_create_note` |
 | "Create a note about X" | `remnote_create_note` |
 | "Search for Y" | `remnote_search` |
 | "Show me note abc123" | `remnote_read_note` |

--- a/src/schemas/remnote-schemas.ts
+++ b/src/schemas/remnote-schemas.ts
@@ -5,6 +5,16 @@ export const CreateNoteSchema = z.object({
   content: z.string().optional().describe('Content as child bullets (newline-separated)'),
   parentId: z.string().optional().describe('Parent Rem ID'),
   tags: z.array(z.string()).optional().describe('Tags to apply'),
+  backText: z.string().optional().describe('Back text for flashcards'),
+  isConcept: z.boolean().optional().describe('Whether to create a Concept card (::)'),
+  isDescriptor: z.boolean().optional().describe('Whether to create a Descriptor card (;;)'),
+});
+
+export const CreateNoteMdSchema = z.object({
+  content: z.string().describe('Markdown text to convert into a hierarchical tree'),
+  title: z.string().optional().describe('Optional parent Rem title to enclose the tree'),
+  parentId: z.string().optional().describe('Parent Rem ID where the tree will be created'),
+  tags: z.array(z.string()).optional().describe('Tags to apply to the root/title Rem'),
 });
 
 export const SearchSchema = z.object({

--- a/src/schemas/remnote-schemas.ts
+++ b/src/schemas/remnote-schemas.ts
@@ -1,21 +1,15 @@
 import { z } from 'zod';
 
-export const CreateNoteSchema = z.object({
-  title: z.string().describe('The title of the note'),
-  content: z.string().optional().describe('Content as child bullets (newline-separated)'),
-  parentId: z.string().optional().describe('Parent Rem ID'),
-  tags: z.array(z.string()).optional().describe('Tags to apply'),
-  backText: z.string().optional().describe('Back text for flashcards'),
-  isConcept: z.boolean().optional().describe('Whether to create a Concept card (::)'),
-  isDescriptor: z.boolean().optional().describe('Whether to create a Descriptor card (;;)'),
-});
-
-export const CreateNoteMdSchema = z.object({
-  content: z.string().describe('Markdown text to convert into a hierarchical tree'),
-  title: z.string().optional().describe('Optional parent Rem title to enclose the tree'),
-  parentId: z.string().optional().describe('Parent Rem ID where the tree will be created'),
-  tags: z.array(z.string()).optional().describe('Tags to apply to the root/title Rem'),
-});
+export const CreateNoteSchema = z
+  .object({
+    title: z.string().optional().describe('The title of the note'),
+    content: z.string().optional().describe('Content as child bullets (markdown supported)'),
+    parentId: z.string().optional().describe('Parent Rem ID'),
+    tags: z.array(z.string()).optional().describe('Tags to apply'),
+  })
+  .refine((value) => value.title !== undefined || value.content !== undefined, {
+    message: 'create_note requires either title or content',
+  });
 
 export const SearchSchema = z.object({
   query: z.string().describe('Search query text'),

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -19,7 +19,7 @@ const NAVIGATION_PRESET = {
 export const CREATE_NOTE_TOOL = {
   name: 'remnote_create_note',
   description:
-    'Create a new note (or flashcard) in RemNote with optional content, parent, tags, and card type (:: or ;;). Recommended preflight once per session: remnote_status.',
+    'Create a new note (or flashcard if provided with backText) in RemNote with optional content, parent, tags, backText, and card type (default with concept card). Recommended preflight once per session: remnote_status.',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -28,8 +28,8 @@ export const CREATE_NOTE_TOOL = {
       parentId: { type: 'string', description: 'Parent Rem ID' },
       tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply' },
       backText: { type: 'string', description: 'Optional back text to create a flashcard' },
-      isConcept: { type: 'boolean', description: 'Whether to explicitly create a Concept card (::)' },
-      isDescriptor: { type: 'boolean', description: 'Whether to explicitly create a Descriptor card (;;)' },
+      isConcept: { type: 'boolean', description: 'Whether to explicitly create a Concept card' },
+      isDescriptor: { type: 'boolean', description: 'Whether to explicitly create a Descriptor card' },
     },
     required: ['title'],
   },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -351,10 +351,10 @@ export const UPDATE_NOTE_TOOL = {
     properties: {
       remId: { type: 'string', description: 'The Rem ID to update' },
       title: { type: 'string', description: 'New title' },
-      appendContent: { type: 'string', description: 'Content to append as children' },
+      appendContent: { type: 'string', description: 'Content to append as children (markdown supported)' },
       replaceContent: {
         type: 'string',
-        description: 'Content to replace direct children (empty string clears children)',
+        description: 'Content to replace direct children (markdown supported, empty string clears children)',
       },
       addTags: { type: 'array', items: { type: 'string' }, description: 'Tags to add' },
       removeTags: { type: 'array', items: { type: 'string' }, description: 'Tags to remove' },
@@ -364,10 +364,10 @@ export const UPDATE_NOTE_TOOL = {
   outputSchema: {
     type: 'object' as const,
     properties: {
-      success: { type: 'boolean', description: 'Whether the update succeeded' },
-      remId: { type: 'string', description: 'Updated note Rem ID' },
+      remIds: { type: 'array', items: { type: 'string' }, description: 'IDs of updated/affected Rems' },
+      titles: { type: 'array', items: { type: 'string' }, description: 'Extracted text for updated Rems' },
     },
-    required: ['success', 'remId'],
+    required: ['remIds', 'titles'],
   },
 };
 
@@ -378,7 +378,7 @@ export const APPEND_JOURNAL_TOOL = {
   inputSchema: {
     type: 'object' as const,
     properties: {
-      content: { type: 'string', description: "Content to append to today's daily document" },
+      content: { type: 'string', description: "Content to append to today's daily document (markdown supported)" },
       timestamp: { type: 'boolean', description: 'Include timestamp (default: true)' },
     },
     required: ['content'],
@@ -386,10 +386,10 @@ export const APPEND_JOURNAL_TOOL = {
   outputSchema: {
     type: 'object' as const,
     properties: {
-      remId: { type: 'string', description: 'Created journal entry Rem ID' },
-      content: { type: 'string', description: 'Final journal entry text written to RemNote' },
+      remIds: { type: 'array', items: { type: 'string' }, description: 'IDs of created journal Rems' },
+      titles: { type: 'array', items: { type: 'string' }, description: 'Extracted text for created Rems' },
     },
-    required: ['remId', 'content'],
+    required: ['remIds', 'titles'],
   },
 };
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { WebSocketServer } from '../websocket-server.js';
-import { CreateNoteSchema } from '../schemas/remnote-schemas.js';
+import { CreateNoteSchema, CreateNoteMdSchema } from '../schemas/remnote-schemas.js';
 import { SearchSchema } from '../schemas/remnote-schemas.js';
 import { SearchByTagSchema } from '../schemas/remnote-schemas.js';
 import { ReadNoteSchema } from '../schemas/remnote-schemas.js';
@@ -19,24 +19,52 @@ const NAVIGATION_PRESET = {
 export const CREATE_NOTE_TOOL = {
   name: 'remnote_create_note',
   description:
-    'Create a new note in RemNote with optional content, parent, and tags. Recommended preflight once per session: remnote_status.',
+    'Create a new note (or flashcard) in RemNote with optional content, parent, tags, and card type (:: or ;;). Recommended preflight once per session: remnote_status.',
   inputSchema: {
     type: 'object' as const,
     properties: {
-      title: { type: 'string', description: 'The title of the note' },
+      title: { type: 'string', description: 'The title of the note (front text for cards)' },
       content: { type: 'string', description: 'Content as child bullets (newline-separated)' },
       parentId: { type: 'string', description: 'Parent Rem ID' },
       tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply' },
+      backText: { type: 'string', description: 'Optional back text to create a flashcard' },
+      isConcept: { type: 'boolean', description: 'Whether to explicitly create a Concept card (::)' },
+      isDescriptor: { type: 'boolean', description: 'Whether to explicitly create a Descriptor card (;;)' },
     },
     required: ['title'],
   },
   outputSchema: {
     type: 'object' as const,
     properties: {
-      remId: { type: 'string', description: 'Created note Rem ID' },
-      title: { type: 'string', description: 'Created note title' },
+      remId: { type: 'string', description: 'Created note/card Rem ID' },
+      title: { type: 'string', description: 'Created note title (front text)' },
+      backText: { type: 'string', description: 'Back text if a card was created' },
     },
     required: ['remId', 'title'],
+  },
+};
+
+export const CREATE_NOTE_MD_TOOL = {
+  name: 'remnote_create_note_md',
+  description:
+    'Create a hierarchical note tree in RemNote from a markdown string (indented bullets). Automatically parses indentations (- or *) into parent-child Rem relationships.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      content: { type: 'string', description: 'Markdown text to convert into a hierarchical tree' },
+      title: { type: 'string', description: 'Optional parent Rem title to enclose the tree' },
+      parentId: { type: 'string', description: 'Parent Rem ID where the tree will be created' },
+      tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply to the root/title Rem' },
+    },
+    required: ['content'],
+  },
+  outputSchema: {
+    type: 'object' as const,
+    properties: {
+      remIds: { type: 'array', items: { type: 'string' }, description: 'List of created Rem IDs (root first)' },
+      title: { type: 'string', description: 'Title of the root Rem, if provided' },
+    },
+    required: ['remIds'],
   },
 };
 
@@ -539,6 +567,12 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
           break;
         }
 
+        case 'remnote_create_note_md': {
+          const args = CreateNoteMdSchema.parse(request.params.arguments);
+          result = await wsServer.sendRequest('create_note_md', args);
+          break;
+        }
+
         case 'remnote_search': {
           const args = SearchSchema.parse(request.params.arguments);
           result = await wsServer.sendRequest('search', args);
@@ -671,6 +705,7 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
     return {
       tools: [
         CREATE_NOTE_TOOL,
+        CREATE_NOTE_MD_TOOL,
         SEARCH_TOOL,
         SEARCH_BY_TAG_TOOL,
         READ_NOTE_TOOL,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { WebSocketServer } from '../websocket-server.js';
-import { CreateNoteSchema, CreateNoteMdSchema } from '../schemas/remnote-schemas.js';
+import { CreateNoteSchema } from '../schemas/remnote-schemas.js';
 import { SearchSchema } from '../schemas/remnote-schemas.js';
 import { SearchByTagSchema } from '../schemas/remnote-schemas.js';
 import { ReadNoteSchema } from '../schemas/remnote-schemas.js';
@@ -19,54 +19,27 @@ const NAVIGATION_PRESET = {
 export const CREATE_NOTE_TOOL = {
   name: 'remnote_create_note',
   description:
-    'Create a new note (or flashcard if provided with backText) in RemNote with optional content, parent, tags, backText, and card type (default with concept card). Recommended preflight once per session: remnote_status.',
+    'Create a new note in RemNote with optional content, parent, and tags. Supports hierarchical markdown in content and flashcard syntax (e.g. "- Term :: Definition"). At least one of title or content must be provided. Recommended preflight once per session: remnote_status.',
   inputSchema: {
     type: 'object' as const,
     properties: {
-      title: { type: 'string', description: 'The title of the note (front text for cards)' },
-      content: { type: 'string', description: 'Content as child bullets (newline-separated)' },
+      title: { type: 'string', description: 'The title of the note (optional if content is provided)' },
+      content: { type: 'string', description: 'Content as plain text, child bullets or hierarchical markdown' },
       parentId: { type: 'string', description: 'Parent Rem ID' },
       tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply' },
-      backText: { type: 'string', description: 'Optional back text to create a flashcard' },
-      isConcept: { type: 'boolean', description: 'Whether to explicitly create a Concept card' },
-      isDescriptor: { type: 'boolean', description: 'Whether to explicitly create a Descriptor card' },
     },
-    required: ['title'],
+    required: [],
   },
   outputSchema: {
     type: 'object' as const,
     properties: {
-      remId: { type: 'string', description: 'Created note/card Rem ID' },
-      title: { type: 'string', description: 'Created note title (front text)' },
-      backText: { type: 'string', description: 'Back text if a card was created' },
+      remIds: { type: 'array', items: { type: 'string' }, description: 'IDs of created Rems (title at index 0, top-to-bottom)' },
+      titles: { type: 'array', items: { type: 'string' }, description: 'Extracted text for each created Rem (title Rem ID at index 0, top-to-bottom)' },
     },
-    required: ['remId', 'title'],
+    required: ['remIds', 'titles'],
   },
 };
 
-export const CREATE_NOTE_MD_TOOL = {
-  name: 'remnote_create_note_md',
-  description:
-    'Create a hierarchical note tree in RemNote from a markdown string (indented bullets). Automatically parses indentations (- or *) into parent-child Rem relationships.',
-  inputSchema: {
-    type: 'object' as const,
-    properties: {
-      content: { type: 'string', description: 'Markdown text to convert into a hierarchical tree' },
-      title: { type: 'string', description: 'Optional parent Rem title to enclose the tree' },
-      parentId: { type: 'string', description: 'Parent Rem ID where the tree will be created' },
-      tags: { type: 'array', items: { type: 'string' }, description: 'Tags to apply to the root/title Rem' },
-    },
-    required: ['content'],
-  },
-  outputSchema: {
-    type: 'object' as const,
-    properties: {
-      remIds: { type: 'array', items: { type: 'string' }, description: 'List of created Rem IDs (root first)' },
-      title: { type: 'string', description: 'Title of the root Rem, if provided' },
-    },
-    required: ['remIds'],
-  },
-};
 
 export const SEARCH_TOOL = {
   name: 'remnote_search',
@@ -567,12 +540,6 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
           break;
         }
 
-        case 'remnote_create_note_md': {
-          const args = CreateNoteMdSchema.parse(request.params.arguments);
-          result = await wsServer.sendRequest('create_note_md', args);
-          break;
-        }
-
         case 'remnote_search': {
           const args = SearchSchema.parse(request.params.arguments);
           result = await wsServer.sendRequest('search', args);
@@ -705,7 +672,6 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
     return {
       tools: [
         CREATE_NOTE_TOOL,
-        CREATE_NOTE_MD_TOOL,
         SEARCH_TOOL,
         SEARCH_BY_TAG_TOOL,
         READ_NOTE_TOOL,

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -67,11 +67,13 @@ export const createBridgeResponse = (
   error,
 });
 
-// Sample RemNote API responses
-export const sampleNoteResult = {
+// Sample RemNote API responses for mutating actions (create, update, journal)
+export const sampleMutatingResult = {
   remIds: ['rem-id-123', 'child-1-id', 'child-2-id'],
   titles: ['Sample Note', 'Child 1', 'Child 2'],
 };
+
+export const sampleNoteResult = sampleMutatingResult;
 
 export const sampleSearchResults = {
   results: [

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -69,9 +69,8 @@ export const createBridgeResponse = (
 
 // Sample RemNote API responses
 export const sampleNoteResult = {
-  id: 'rem-id-123',
-  title: 'Sample Note',
-  content: ['Child 1', 'Child 2'],
+  remIds: ['rem-id-123', 'child-1-id', 'child-2-id'],
+  titles: ['Sample Note', 'Child 1', 'Child 2'],
 };
 
 export const sampleSearchResults = {

--- a/test/integration/types.ts
+++ b/test/integration/types.ts
@@ -32,6 +32,8 @@ export interface SharedState {
   searchByTagTag?: string;
   noteAId?: string;
   noteBId?: string;
+  noteCId?: string;
+  mdTreeIds?: string[];
   acceptWriteOperations?: boolean;
   acceptReplaceOperation?: boolean;
 }

--- a/test/integration/workflows/02-create-search.ts
+++ b/test/integration/workflows/02-create-search.ts
@@ -212,6 +212,78 @@ export async function createSearchWorkflow(
     }
   }
 
+  // Step 3: Create flashcard note (with back-text)
+  {
+    const start = Date.now();
+    try {
+      const result = await ctx.client.callTool('remnote_create_note', {
+        title: `[MCP-TEST] Flashcard Note ${ctx.runId}`,
+        parentId: state.integrationParentRemId,
+        backText: 'This is the back of the flashcard',
+        isConcept: true,
+        tags: [state.searchByTagTag as string],
+      });
+      assertHasField(result, 'remId', 'create flashcard note');
+      assertTruthy(typeof result.remId === 'string', 'remId should be a string');
+      state.noteCId = result.remId as string;
+      steps.push({ label: 'Create flashcard note', passed: true, durationMs: Date.now() - start });
+    } catch (e) {
+      steps.push({
+        label: 'Create flashcard note',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 4: Create markdown tree with various flashcard types
+  {
+    const start = Date.now();
+    try {
+      const markdownContent = [
+        `- Flashcard Tree`,
+        `  - Basic Forward >> Answer`,
+        `  - Basic Backward << Answer`,
+        `  - Two-way :: Answer`,
+        `  - Disabled >- Answer`,
+        `  - Cloze with {{hidden}}{({hint text})} text`,
+        `  - Concept :: Definition`,
+        `  - Concept Forward :> Definition`,
+        `  - Concept Backward :< Definition`,
+        `  - Descriptor ;; Detail`,
+        `  - Multi-line >>>`,
+        `    - Card Item 1`,
+        `    - Card Item 2`,
+        `  - List-answer >>1.`,
+        `    - First list item`,
+        `    - Second list item`,
+        `  - Multiple-choice >>A)`,
+        `    - Correct option`,
+        `    - Wrong option`
+      ].join('\n');
+
+      const result = await ctx.client.callTool('remnote_create_note_md', {
+        content: markdownContent,
+        title: `[MCP-TEST] Flashcard Tree ${ctx.runId}`,
+        parentId: state.integrationParentRemId,
+        tags: [state.searchByTagTag as string],
+      });
+
+      assertHasField(result, 'remIds', 'create markdown tree');
+      assertIsArray(result.remIds, 'markdown tree remIds');
+      state.mdTreeIds = result.remIds as string[];
+      steps.push({ label: 'Create md tree with flashcards', passed: true, durationMs: Date.now() - start });
+    } catch (e) {
+      steps.push({
+        label: 'Create md tree with flashcards',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
   // Wait for RemNote indexing
   await new Promise((resolve) => setTimeout(resolve, delay));
 
@@ -251,7 +323,7 @@ export async function createSearchWorkflow(
   for (const mode of ['markdown', 'structured', 'none'] as const) {
     const start = Date.now();
     const label = `Search includeContent=${mode} returns expected shape`;
-    const query = `[MCP-TEST] ${ctx.runId}`;
+    const query = `${ctx.runId}`;
     let debugResults: Array<Record<string, unknown>> | null = null;
     try {
       const result = await ctx.client.callTool('remnote_search', {

--- a/test/integration/workflows/02-create-search.ts
+++ b/test/integration/workflows/02-create-search.ts
@@ -161,34 +161,6 @@ export async function createSearchWorkflow(
   if (!state.searchByTagTag) {
     state.searchByTagTag = `mcp-test-tag-${ctx.runId.replace(/[^a-zA-Z0-9]/g, '-')}`;
   }
-  // Step 0: Verify error on empty create (bridge-side validation)
-  {
-    const start = Date.now();
-    try {
-      try {
-        await ctx.client.callTool('remnote_create_note', {});
-        throw new Error('Should have failed on empty input');
-      } catch (e: any) {
-        // Success case: bridge should throw 'create_note requires either title or content'
-        const msg = e.message || String(e);
-        if (msg.includes('Should have failed')) {
-          throw e;
-        }
-      }
-      steps.push({
-        label: 'Verify error on empty create',
-        passed: true,
-        durationMs: Date.now() - start,
-      });
-    } catch (e) {
-      steps.push({
-        label: 'Verify error on empty create',
-        passed: false,
-        durationMs: Date.now() - start,
-        error: (e as Error).message,
-      });
-    }
-  }
   // Step 1: Create simple note
   {
     const start = Date.now();

--- a/test/integration/workflows/02-create-search.ts
+++ b/test/integration/workflows/02-create-search.ts
@@ -161,18 +161,45 @@ export async function createSearchWorkflow(
   if (!state.searchByTagTag) {
     state.searchByTagTag = `mcp-test-tag-${ctx.runId.replace(/[^a-zA-Z0-9]/g, '-')}`;
   }
-
+  // Step 0: Verify error on empty create (bridge-side validation)
+  {
+    const start = Date.now();
+    try {
+      try {
+        await ctx.client.callTool('remnote_create_note', {});
+        throw new Error('Should have failed on empty input');
+      } catch (e: any) {
+        // Success case: bridge should throw 'create_note requires either title or content'
+        const msg = e.message || String(e);
+        if (msg.includes('Should have failed')) {
+          throw e;
+        }
+      }
+      steps.push({
+        label: 'Verify error on empty create',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Verify error on empty create',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
   // Step 1: Create simple note
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_create_note', {
+      const result = (await ctx.client.callTool('remnote_create_note', {
         title: `[MCP-TEST] Simple Note ${ctx.runId}`,
         parentId: state.integrationParentRemId,
-      });
-      assertHasField(result, 'remId', 'create simple note');
-      assertTruthy(typeof result.remId === 'string', 'remId should be a string');
-      state.noteAId = result.remId as string;
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'create simple note');
+      assertIsArray(result.remIds, 'remIds should be an array');
+      state.noteAId = result.remIds[0];
       steps.push({ label: 'Create simple note', passed: true, durationMs: Date.now() - start });
     } catch (e) {
       steps.push({
@@ -188,15 +215,15 @@ export async function createSearchWorkflow(
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_create_note', {
+      const result = (await ctx.client.callTool('remnote_create_note', {
         title: `[MCP-TEST] Rich Note ${ctx.runId}`,
         parentId: state.integrationParentRemId,
         content: 'Bullet one\nBullet two\nBullet three',
         tags: [state.searchByTagTag],
-      });
-      assertHasField(result, 'remId', 'create rich note');
-      assertTruthy(typeof result.remId === 'string', 'remId should be a string');
-      state.noteBId = result.remId as string;
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'create rich note');
+      assertIsArray(result.remIds, 'remIds should be an array');
+      state.noteBId = result.remIds[0];
       steps.push({
         label: 'Create rich note with content and tags',
         passed: true,
@@ -212,20 +239,19 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 3: Create flashcard note (with back-text)
+  // Step 3: Create flashcard note
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_create_note', {
+      const result = (await ctx.client.callTool('remnote_create_note', {
         title: `[MCP-TEST] Flashcard Note ${ctx.runId}`,
         parentId: state.integrationParentRemId,
-        backText: 'This is the back of the flashcard',
-        isConcept: true,
+        content: 'Front :: Back',
         tags: [state.searchByTagTag as string],
-      });
-      assertHasField(result, 'remId', 'create flashcard note');
-      assertTruthy(typeof result.remId === 'string', 'remId should be a string');
-      state.noteCId = result.remId as string;
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'create flashcard note');
+      assertIsArray(result.remIds, 'remIds should be an array');
+      state.noteCId = result.remIds[0];
       steps.push({ label: 'Create flashcard note', passed: true, durationMs: Date.now() - start });
     } catch (e) {
       steps.push({
@@ -263,12 +289,12 @@ export async function createSearchWorkflow(
         `    - Wrong option`
       ].join('\n');
 
-      const result = await ctx.client.callTool('remnote_create_note_md', {
+      const result = (await ctx.client.callTool('remnote_create_note', {
         content: markdownContent,
         title: `[MCP-TEST] Flashcard Tree ${ctx.runId}`,
         parentId: state.integrationParentRemId,
         tags: [state.searchByTagTag as string],
-      });
+      })) as { remIds: string[] };
 
       assertHasField(result, 'remIds', 'create markdown tree');
       assertIsArray(result.remIds, 'markdown tree remIds');
@@ -287,7 +313,7 @@ export async function createSearchWorkflow(
   // Wait for RemNote indexing
   await new Promise((resolve) => setTimeout(resolve, delay));
 
-  // Step 3: Search finds simple note
+  // Step 5: Search finds simple note
   {
     const start = Date.now();
     try {
@@ -319,7 +345,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 4-6: Search with includeContent modes
+  // Step 6-8: Search with includeContent modes
   for (const mode of ['markdown', 'structured', 'none'] as const) {
     const start = Date.now();
     const label = `Search includeContent=${mode} returns expected shape`;
@@ -362,7 +388,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 7-9: Search by tag with includeContent modes
+  // Step 9-11: Search by tag with includeContent modes
   let expectedTagTarget: ExpectedTagTarget | undefined;
   {
     const start = Date.now();

--- a/test/integration/workflows/03-read-update.ts
+++ b/test/integration/workflows/03-read-update.ts
@@ -5,7 +5,7 @@
  * and re-reads to verify the changes persisted.
  */
 
-import { assertTruthy, assertHasField, assertContains, assertEqual } from '../assertions.js';
+import { assertTruthy, assertHasField, assertContains, assertEqual, assertIsArray } from '../assertions.js';
 import type { WorkflowContext, WorkflowResult, SharedState, StepResult } from '../types.js';
 
 function summarizeReadResult(result: Record<string, unknown>): Record<string, unknown> {
@@ -164,11 +164,12 @@ export async function readUpdateWorkflow(
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_update_note', {
+      const result = (await ctx.client.callTool('remnote_update_note', {
         remId: state.noteAId,
         title: `[MCP-TEST] Updated Note ${ctx.runId}`,
-      });
-      assertTruthy(result.success, 'update title should succeed');
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'update title should succeed');
+      assertIsArray(result.remIds, 'update title remIds');
       steps.push({ label: 'Update title', passed: true, durationMs: Date.now() - start });
     } catch (e) {
       steps.push({
@@ -184,11 +185,12 @@ export async function readUpdateWorkflow(
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_update_note', {
+      const result = (await ctx.client.callTool('remnote_update_note', {
         remId: state.noteAId,
         appendContent: 'Appended via integration test',
-      });
-      assertTruthy(result.success, 'append content should succeed');
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'append content should succeed');
+      assertIsArray(result.remIds, 'append content remIds');
       steps.push({ label: 'Append content', passed: true, durationMs: Date.now() - start });
     } catch (e) {
       steps.push({
@@ -206,11 +208,12 @@ export async function readUpdateWorkflow(
     try {
       if (acceptReplaceOperation) {
         const replaceBody = `[MCP-TEST] Replaced via integration test ${ctx.runId}`;
-        const result = await ctx.client.callTool('remnote_update_note', {
+        const result = (await ctx.client.callTool('remnote_update_note', {
           remId: state.noteAId,
           replaceContent: replaceBody,
-        });
-        assertTruthy(result.success, 'replace content should succeed when enabled');
+        })) as { remIds: string[] };
+        assertHasField(result, 'remIds', 'replace content should succeed when enabled');
+        assertIsArray(result.remIds, 'replace content remIds');
 
         const reread = await ctx.client.callTool('remnote_read_note', {
           remId: state.noteAId,
@@ -254,11 +257,12 @@ export async function readUpdateWorkflow(
   if (acceptReplaceOperation) {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_update_note', {
+      const result = (await ctx.client.callTool('remnote_update_note', {
         remId: state.noteAId,
         replaceContent: '',
-      });
-      assertTruthy(result.success, 'empty replace should succeed');
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'empty replace should succeed');
+      assertIsArray(result.remIds, 'empty replace remIds');
 
       const reread = await ctx.client.callTool('remnote_read_note', {
         remId: state.noteAId,
@@ -289,11 +293,12 @@ export async function readUpdateWorkflow(
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_update_note', {
+      const result = (await ctx.client.callTool('remnote_update_note', {
         remId: state.noteAId,
         addTags: ['mcp-integration-verified'],
-      });
-      assertTruthy(result.success, 'add tag should succeed');
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'add tag should succeed');
+      assertIsArray(result.remIds, 'add tag remIds');
       steps.push({ label: 'Add tag', passed: true, durationMs: Date.now() - start });
     } catch (e) {
       steps.push({
@@ -309,11 +314,12 @@ export async function readUpdateWorkflow(
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_update_note', {
+      const result = (await ctx.client.callTool('remnote_update_note', {
         remId: state.noteAId,
         removeTags: ['mcp-integration-verified'],
-      });
-      assertTruthy(result.success, 'remove tag should succeed');
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'remove tag should succeed');
+      assertIsArray(result.remIds, 'remove tag remIds');
       steps.push({ label: 'Remove tag', passed: true, durationMs: Date.now() - start });
     } catch (e) {
       steps.push({
@@ -343,6 +349,34 @@ export async function readUpdateWorkflow(
     } catch (e) {
       steps.push({
         label: 'Re-read verifies changes',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 10: Update with markdown tree
+  {
+    const start = Date.now();
+    try {
+      const markdownTree = `[MCP-TEST] Markdown Tree ${ctx.runId}\n- Branch 1\n  - Leaf 1\n- Branch 2`;
+      const result = (await ctx.client.callTool('remnote_update_note', {
+        remId: state.noteAId,
+        appendContent: markdownTree,
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'update with markdown tree');
+      assertIsArray(result.remIds, 'markdown tree remIds');
+      assertTruthy(result.remIds.length >= 4, 'should create multiple rems for tree');
+
+      steps.push({
+        label: 'Update with markdown tree',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Update with markdown tree',
         passed: false,
         durationMs: Date.now() - start,
         error: (e as Error).message,

--- a/test/integration/workflows/04-journal.ts
+++ b/test/integration/workflows/04-journal.ts
@@ -4,7 +4,7 @@
  * Appends entries to today's daily document with and without timestamps.
  */
 
-import { assertTruthy, assertHasField } from '../assertions.js';
+import { assertTruthy, assertHasField, assertIsArray } from '../assertions.js';
 import type { WorkflowContext, WorkflowResult, SharedState, StepResult } from '../types.js';
 
 export async function journalWorkflow(
@@ -17,11 +17,11 @@ export async function journalWorkflow(
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_append_journal', {
+      const result = (await ctx.client.callTool('remnote_append_journal', {
         content: `[MCP-TEST] Journal entry ${ctx.runId}`,
-      });
-      assertHasField(result, 'remId', 'journal append with timestamp');
-      assertTruthy(typeof result.remId === 'string', 'remId should be a string');
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'journal append with timestamp');
+      assertIsArray(result.remIds, 'remIds should be an array');
       steps.push({ label: 'Append with timestamp', passed: true, durationMs: Date.now() - start });
     } catch (e) {
       steps.push({
@@ -37,11 +37,12 @@ export async function journalWorkflow(
   {
     const start = Date.now();
     try {
-      const result = await ctx.client.callTool('remnote_append_journal', {
+      const result = (await ctx.client.callTool('remnote_append_journal', {
         content: `[MCP-TEST] No-timestamp entry ${ctx.runId}`,
         timestamp: false,
-      });
-      assertHasField(result, 'remId', 'journal append without timestamp');
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'journal append without timestamp');
+      assertIsArray(result.remIds, 'remIds should be an array');
       steps.push({
         label: 'Append without timestamp',
         passed: true,
@@ -50,6 +51,31 @@ export async function journalWorkflow(
     } catch (e) {
       steps.push({
         label: 'Append without timestamp',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 3: Append with markdown
+  {
+    const start = Date.now();
+    try {
+      const result = (await ctx.client.callTool('remnote_append_journal', {
+        content: `[MCP-TEST] Markdown entry ${ctx.runId}\n\n## Section\n- Item 1\n- Item 2`,
+      })) as { remIds: string[] };
+      assertHasField(result, 'remIds', 'journal append with markdown');
+      assertIsArray(result.remIds, 'remIds should be an array');
+      assertTruthy(result.remIds.length >= 3, 'should create multiple rems for markdown');
+      steps.push({
+        label: 'Append with markdown',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Append with markdown',
         passed: false,
         durationMs: Date.now() - start,
         error: (e as Error).message,

--- a/test/integration/workflows/05-error-cases.ts
+++ b/test/integration/workflows/05-error-cases.ts
@@ -15,7 +15,36 @@ export async function errorCasesWorkflow(
 ): Promise<WorkflowResult> {
   const steps: StepResult[] = [];
 
-  // Step 1: Read nonexistent note returns error
+  // Step 1: Verify error on empty create (bridge-side validation)
+  {
+    const start = Date.now();
+    try {
+      try {
+        await ctx.client.callTool('remnote_create_note', {});
+        throw new Error('Should have failed on empty input');
+      } catch (e: any) {
+        // Success case: bridge should throw 'create_note requires either title or content'
+        const msg = e.message || String(e);
+        if (msg.includes('Should have failed')) {
+          throw e;
+        }
+      }
+      steps.push({
+        label: 'Verify error on empty create',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Verify error on empty create',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 2: Read nonexistent note returns error
   {
     const start = Date.now();
     try {
@@ -47,7 +76,7 @@ export async function errorCasesWorkflow(
     }
   }
 
-  // Step 2: Update nonexistent note returns error
+  // Step 3: Update nonexistent note returns error
   {
     const start = Date.now();
     try {
@@ -71,35 +100,6 @@ export async function errorCasesWorkflow(
       } else {
         steps.push({
           label: 'Update nonexistent note returns error',
-          passed: false,
-          durationMs: Date.now() - start,
-          error: (e as Error).message,
-        });
-      }
-    }
-  }
-
-  // Step 3: Create without title returns validation error
-  {
-    const start = Date.now();
-    try {
-      const errorText = await ctx.client.callToolExpectError('remnote_create_note', {});
-      assertTruthy(errorText, 'should return validation error for missing title');
-      steps.push({
-        label: 'Create without title returns validation error',
-        passed: true,
-        durationMs: Date.now() - start,
-      });
-    } catch (e) {
-      if (e instanceof ToolError) {
-        steps.push({
-          label: 'Create without title returns validation error',
-          passed: true,
-          durationMs: Date.now() - start,
-        });
-      } else {
-        steps.push({
-          label: 'Create without title returns validation error',
           passed: false,
           durationMs: Date.now() - start,
           error: (e as Error).message,

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   CreateNoteSchema,
-  CreateNoteMdSchema,
   SearchSchema,
   SearchByTagSchema,
   ReadNoteSchema,
@@ -15,12 +14,18 @@ import {
 } from '../../src/schemas/remnote-schemas.js';
 
 describe('CreateNoteSchema', () => {
-  it('should validate with only required title field', () => {
+  it('should validate with only title field', () => {
     const result = CreateNoteSchema.parse({ title: 'Test' });
     expect(result.title).toBe('Test');
     expect(result.content).toBeUndefined();
     expect(result.parentId).toBeUndefined();
     expect(result.tags).toBeUndefined();
+  });
+
+  it('should validate with only content field', () => {
+    const result = CreateNoteSchema.parse({ content: '- item' });
+    expect(result.content).toBe('- item');
+    expect(result.title).toBeUndefined();
   });
 
   it('should validate with all fields', () => {
@@ -29,16 +34,13 @@ describe('CreateNoteSchema', () => {
       content: 'Content',
       parentId: 'parent-123',
       tags: ['tag1', 'tag2'],
-      backText: 'Back text',
-      isConcept: true,
-      isDescriptor: false,
     };
     const result = CreateNoteSchema.parse(input);
     expect(result).toEqual(input);
   });
 
-  it('should reject missing title', () => {
-    expect(() => CreateNoteSchema.parse({})).toThrow();
+  it('should reject empty object', () => {
+    expect(() => CreateNoteSchema.parse({})).toThrow('create_note requires either title or content');
   });
 
   it('should reject non-string title', () => {
@@ -50,30 +52,6 @@ describe('CreateNoteSchema', () => {
   });
 });
 
-describe('CreateNoteMdSchema', () => {
-  it('should validate with only required content field', () => {
-    const result = CreateNoteMdSchema.parse({ content: '- item1\n  - item2' });
-    expect(result.content).toBe('- item1\n  - item2');
-    expect(result.title).toBeUndefined();
-    expect(result.parentId).toBeUndefined();
-    expect(result.tags).toBeUndefined();
-  });
-
-  it('should validate with all fields', () => {
-    const input = {
-      content: '- item',
-      title: 'Root Title',
-      parentId: 'parent-123',
-      tags: ['tag1'],
-    };
-    const result = CreateNoteMdSchema.parse(input);
-    expect(result).toEqual(input);
-  });
-
-  it('should reject missing content', () => {
-    expect(() => CreateNoteMdSchema.parse({})).toThrow();
-  });
-});
 
 describe('SearchSchema', () => {
   it('should validate with only required query field', () => {

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   CreateNoteSchema,
+  CreateNoteMdSchema,
   SearchSchema,
   SearchByTagSchema,
   ReadNoteSchema,
@@ -28,6 +29,9 @@ describe('CreateNoteSchema', () => {
       content: 'Content',
       parentId: 'parent-123',
       tags: ['tag1', 'tag2'],
+      backText: 'Back text',
+      isConcept: true,
+      isDescriptor: false,
     };
     const result = CreateNoteSchema.parse(input);
     expect(result).toEqual(input);
@@ -43,6 +47,31 @@ describe('CreateNoteSchema', () => {
 
   it('should reject non-array tags', () => {
     expect(() => CreateNoteSchema.parse({ title: 'Test', tags: 'not-array' })).toThrow();
+  });
+});
+
+describe('CreateNoteMdSchema', () => {
+  it('should validate with only required content field', () => {
+    const result = CreateNoteMdSchema.parse({ content: '- item1\n  - item2' });
+    expect(result.content).toBe('- item1\n  - item2');
+    expect(result.title).toBeUndefined();
+    expect(result.parentId).toBeUndefined();
+    expect(result.tags).toBeUndefined();
+  });
+
+  it('should validate with all fields', () => {
+    const input = {
+      content: '- item',
+      title: 'Root Title',
+      parentId: 'parent-123',
+      tags: ['tag1'],
+    };
+    const result = CreateNoteMdSchema.parse(input);
+    expect(result).toEqual(input);
+  });
+
+  it('should reject missing content', () => {
+    expect(() => CreateNoteMdSchema.parse({})).toThrow();
   });
 });
 

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -25,6 +25,7 @@ import {
   validUpdateNoteInput,
   validUpdateReplaceInput,
   validAppendJournalInput,
+  sampleMutatingResult,
   sampleNoteResult,
   sampleSearchResults,
   sampleStatusResult,
@@ -153,12 +154,24 @@ describe('Tool Definitions', () => {
     expect(properties.replaceContent).toBeDefined();
   });
 
+  it('should have plural remIds and titles in UPDATE_NOTE_TOOL output schema', () => {
+    const properties = UPDATE_NOTE_TOOL.outputSchema.properties as Record<string, any>;
+    expect(properties.remIds).toBeDefined();
+    expect(properties.titles).toBeDefined();
+  });
+
   it('should have correct name for APPEND_JOURNAL_TOOL', () => {
     expect(APPEND_JOURNAL_TOOL.name).toBe('remnote_append_journal');
   });
 
   it('should have required content field for APPEND_JOURNAL_TOOL', () => {
     expect(APPEND_JOURNAL_TOOL.inputSchema.required).toContain('content');
+  });
+
+  it('should have plural remIds and titles in APPEND_JOURNAL_TOOL output schema', () => {
+    const properties = APPEND_JOURNAL_TOOL.outputSchema.properties as Record<string, any>;
+    expect(properties.remIds).toBeDefined();
+    expect(properties.titles).toBeDefined();
   });
 
   it('should have correct name for STATUS_TOOL', () => {
@@ -441,7 +454,7 @@ describe('Tool Handlers - update_note', () => {
   beforeEach(() => {
     mockServer = new MockMCPServer();
     mockWsServer = {
-      sendRequest: vi.fn().mockResolvedValue({ success: true }),
+      sendRequest: vi.fn().mockResolvedValue(sampleMutatingResult),
     };
     registerAllTools(mockServer as never, mockWsServer as never, createMockLogger() as never);
   });
@@ -470,6 +483,15 @@ describe('Tool Handlers - update_note', () => {
     expect(mockWsServer.sendRequest).toHaveBeenCalledWith('update_note', validUpdateReplaceInput);
   });
 
+  it('should return formatted JSON result with plural fields', async () => {
+    const result = (await mockServer.callHandler(CallToolRequestSchema, {
+      params: { name: 'remnote_update_note', arguments: validUpdateNoteInput },
+    })) as { content: { type: string; text: string }[] };
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual(sampleMutatingResult);
+  });
+
   it('should reject update requests that include both appendContent and replaceContent', async () => {
     const result = (await mockServer.callHandler(CallToolRequestSchema, {
       params: {
@@ -496,7 +518,7 @@ describe('Tool Handlers - append_journal', () => {
   beforeEach(() => {
     mockServer = new MockMCPServer();
     mockWsServer = {
-      sendRequest: vi.fn().mockResolvedValue({ success: true }),
+      sendRequest: vi.fn().mockResolvedValue(sampleMutatingResult),
     };
     registerAllTools(mockServer as never, mockWsServer as never, createMockLogger() as never);
   });
@@ -521,6 +543,15 @@ describe('Tool Handlers - append_journal', () => {
       content: 'test',
       timestamp: true, // default
     });
+  });
+
+  it('should return formatted JSON result with plural fields', async () => {
+    const result = (await mockServer.callHandler(CallToolRequestSchema, {
+      params: { name: 'remnote_append_journal', arguments: validAppendJournalInput },
+    })) as { content: { type: string; text: string }[] };
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual(sampleMutatingResult);
   });
 });
 
@@ -737,7 +768,7 @@ describe('Tool Logging', () => {
   beforeEach(() => {
     mockServer = new MockMCPServer();
     mockWsServer = {
-      sendRequest: vi.fn().mockResolvedValue({ success: true }),
+      sendRequest: vi.fn().mockResolvedValue(sampleMutatingResult),
     };
     mockLogger = createMockLogger();
     registerAllTools(mockServer as never, mockWsServer as never, mockLogger);

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   registerAllTools,
   CREATE_NOTE_TOOL,
-  CREATE_NOTE_MD_TOOL,
   SEARCH_TOOL,
   SEARCH_BY_TAG_TOOL,
   READ_NOTE_TOOL,
@@ -58,17 +57,10 @@ describe('Tool Definitions', () => {
     expect(CREATE_NOTE_TOOL.name).toBe('remnote_create_note');
   });
 
-  it('should have required title field for CREATE_NOTE_TOOL', () => {
-    expect(CREATE_NOTE_TOOL.inputSchema.required).toContain('title');
+  it('should allow optional title field for CREATE_NOTE_TOOL', () => {
+    expect(CREATE_NOTE_TOOL.inputSchema.required).not.toContain('title');
   });
 
-  it('should have correct name for CREATE_NOTE_MD_TOOL', () => {
-    expect(CREATE_NOTE_MD_TOOL.name).toBe('remnote_create_note_md');
-  });
-
-  it('should have required content field for CREATE_NOTE_MD_TOOL', () => {
-    expect(CREATE_NOTE_MD_TOOL.inputSchema.required).toContain('content');
-  });
 
   it('should have correct name for SEARCH_TOOL', () => {
     expect(SEARCH_TOOL.name).toBe('remnote_search');
@@ -212,7 +204,7 @@ describe('Tool Registration', () => {
       tools: unknown[];
     };
 
-    expect(result.tools).toHaveLength(9);
+    expect(result.tools).toHaveLength(8);
   });
 
   it('should include all tool names in list', async () => {
@@ -224,7 +216,6 @@ describe('Tool Registration', () => {
 
     const names = result.tools.map((t) => t.name);
     expect(names).toContain('remnote_create_note');
-    expect(names).toContain('remnote_create_note_md');
     expect(names).toContain('remnote_search');
     expect(names).toContain('remnote_search_by_tag');
     expect(names).toContain('remnote_read_note');
@@ -267,13 +258,13 @@ describe('Tool Handlers - create_note', () => {
     expect(parsed).toEqual(sampleNoteResult);
   });
 
-  it('should reject invalid input', async () => {
+  it('should allow input without title', async () => {
     const result = (await mockServer.callHandler(CallToolRequestSchema, {
-      params: { name: 'remnote_create_note', arguments: {} }, // Missing title
+      params: { name: 'remnote_create_note', arguments: { content: '- item' } },
     })) as { isError: boolean; content: { text: string }[] };
 
-    expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('Error');
+    expect(result.isError).toBeUndefined();
+    expect(mockWsServer.sendRequest).toHaveBeenCalledWith('create_note', { content: '- item' });
   });
 });
 

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   registerAllTools,
   CREATE_NOTE_TOOL,
+  CREATE_NOTE_MD_TOOL,
   SEARCH_TOOL,
   SEARCH_BY_TAG_TOOL,
   READ_NOTE_TOOL,
@@ -59,6 +60,14 @@ describe('Tool Definitions', () => {
 
   it('should have required title field for CREATE_NOTE_TOOL', () => {
     expect(CREATE_NOTE_TOOL.inputSchema.required).toContain('title');
+  });
+
+  it('should have correct name for CREATE_NOTE_MD_TOOL', () => {
+    expect(CREATE_NOTE_MD_TOOL.name).toBe('remnote_create_note_md');
+  });
+
+  it('should have required content field for CREATE_NOTE_MD_TOOL', () => {
+    expect(CREATE_NOTE_MD_TOOL.inputSchema.required).toContain('content');
   });
 
   it('should have correct name for SEARCH_TOOL', () => {
@@ -196,14 +205,14 @@ describe('Tool Registration', () => {
     expect(mockServer.hasHandler(ListToolsRequestSchema)).toBe(true);
   });
 
-  it('should return all 8 tools in list', async () => {
+  it('should return all 9 tools in list', async () => {
     registerAllTools(mockServer as never, mockWsServer as never, createMockLogger());
 
     const result = (await mockServer.callHandler(ListToolsRequestSchema, {})) as {
       tools: unknown[];
     };
 
-    expect(result.tools).toHaveLength(8);
+    expect(result.tools).toHaveLength(9);
   });
 
   it('should include all tool names in list', async () => {
@@ -215,6 +224,7 @@ describe('Tool Registration', () => {
 
     const names = result.tools.map((t) => t.name);
     expect(names).toContain('remnote_create_note');
+    expect(names).toContain('remnote_create_note_md');
     expect(names).toContain('remnote_search');
     expect(names).toContain('remnote_search_by_tag');
     expect(names).toContain('remnote_read_note');


### PR DESCRIPTION
### Summary 🎯

Thanks you for building this! This MCP and CLI toolset is an amazing foundation and has been a massive help to my workflow.

The main motivation behind this PR was to streamline my own study routine. By adding support for hierarchical Markdown imports and flashcard back-text, I can now use AI to turn dense notes into active-recall cards almost instantly. 

This PR enhances the RemNote MCP Server and CLI tools by introducing **Hierarchical Markdown Import** and **Flashcard Back-text support**. 
These updates enable AI agents and users to generate complex knowledge structures from a single indented markdown string and precisely define flashcards with their corresponding back-side content, significantly improving the efficiency of automated knowledge ingestion.

### Changes 🔁

#### 🆕 Features & Enhancements
- **Added `remnote_create_note_md` tool**: Supports creating a tree structure in RemNote from an indented markdown string. It automatically parses common RemNote flashcard syntaxes like `>>`, `::`, `><`, and `{{cloze}}`.
- **Extended `remnote_create_note` tool**:
    - Added `backText` parameter: Allows defining the back of a flashcard during creation.
    - Added `isConcept` and `isDescriptor` flags: Enables explicit control over the Rem type/card format.
- **CLI parity**: Synchronized all features to the `remnote-cli` project, adding the `create-md` command and updating the `create` command options.
#### 🛠️ Testing Improvements
- **Unit Tests**:
    - Updated `CreateNoteSchema` to validate new flashcard-related fields.
    - Added comprehensive validation for `CreateNoteMdSchema`.
    - Verified that the MCP Tool registry correctly reflects the addition of the new tool.
- **Integration Tests**:
    - Expanded the `02-create-search.ts` workflow to include test cases for creating flashcards with back-text and complex markdown trees.
    - Fixed a potential crash in tests (Unhandled Rejection) by utilizing optional chaining when accessing generated Rem IDs.
#### Demo
- For card/flashcard created from markdown text
    - Input and tool chaining: 

      <img width="477" height="645" alt="image" src="https://github.com/user-attachments/assets/6e429ede-6b94-4f3c-a7e6-70dc699b5823" />

    - Remnote result:

      <img width="876" height="615" alt="image" src="https://github.com/user-attachments/assets/be07f768-efc6-45fc-9ed8-542613cdd257" />

- For card creation
    - Input:

      <img width="457" height="501" alt="image" src="https://github.com/user-attachments/assets/9592ee96-4ddc-4161-811c-8ffbef50882c" />

    - Remnote result:

      <img width="424" height="28" alt="image" src="https://github.com/user-attachments/assets/bd76225a-0c7b-4f17-a337-b7e79846b19d" />


#### 📖 Documentation
- Updated `AGENTS.md` and `tools-reference.md` to document the new tool parameters with clear examples.
- Updated `CHANGELOG.md` with version-specific entries for these features.

#### Reference
- [how-to-import-flashcards-from-text](https://help.remnote.com/en/articles/9252072-how-to-import-flashcards-from-text#h_fc1588b3b7)
- [Offical api for markdown import](https://plugins.remnote.com/api/classes/RemNamespace#createtreewithmarkdown)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 