### PR TITLE
Add remnote_read_table MCP tool for Advanced Tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- New `remnote_read_table` tool for reading Advanced Table data (columns, rows, cell values)
+- `ReadTableSchema` Zod validation schema with pagination (limit/offset) and propertyFilter support
+- Playbook decision tree updated with table-reading guidance
+
 ## [0.10.0] - 2026-03-18
 
 ### Documentation

--- a/docs/guides/integration-testing.md
+++ b/docs/guides/integration-testing.md
@@ -68,3 +68,40 @@ To clean up: search your RemNote knowledge base for `[MCP-TEST]` and delete the 
 The integration tests are deliberately separate from the unit test suite. They require external infrastructure (running
 server + connected plugin), create real content, and take seconds rather than milliseconds. They run via `tsx` with
 custom lightweight assertions — no vitest dependency — to keep them independent of the mocked test environment.
+
+---
+
+## Testing read_table
+
+The read_table integration test (workflow 06) requires an Advanced Table in RemNote to be pre-configured. This allows
+testing the table reading functionality without needing write operations.
+
+### Setup
+
+1. Create an Advanced Table in RemNote with some data (at least one column and one row)
+2. Find the table's name or `remId` (you can use the table name directly or get the remId from the browser's developer console)
+3. Create or edit the config file at:
+
+   **Windows:** `C:\Users\<your-username>\.remnote-mcp-bridge\remnote-mcp-bridge.json`
+
+   **macOS/Linux:** `~/.remnote-mcp-bridge/remnote-mcp-bridge.json`
+
+4. Add the integration test configuration (use either `tableNameOrId` with the table name or the table's remId):
+
+```json
+{
+  "integrationTest": {
+    "tableNameOrId": "Your Table Name"
+  }
+}
+```
+
+### Running
+
+After setting up the config, run the integration tests as usual:
+
+```bash
+npm run test:integration
+```
+
+The read_table workflow will be skipped with a warning if the config is missing or invalid.

--- a/src/schemas/remnote-schemas.ts
+++ b/src/schemas/remnote-schemas.ts
@@ -121,3 +121,10 @@ export const AppendJournalSchema = z.object({
   content: z.string().describe("Content to append to today's daily document"),
   timestamp: z.boolean().default(true).describe('Include timestamp'),
 });
+
+export const ReadTableSchema = z.object({
+  tableNameOrId: z.string().min(1).describe('Table Rem ID or tag name'),
+  limit: z.number().int().min(1).max(150).default(50).describe('Maximum rows to return'),
+  offset: z.number().int().min(0).default(0).describe('0-based row offset for pagination'),
+  propertyFilter: z.array(z.string()).optional().describe('Only return these property names'),
+});

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,6 +7,7 @@ import { SearchByTagSchema } from '../schemas/remnote-schemas.js';
 import { ReadNoteSchema } from '../schemas/remnote-schemas.js';
 import { UpdateNoteSchema } from '../schemas/remnote-schemas.js';
 import { AppendJournalSchema } from '../schemas/remnote-schemas.js';
+import { ReadTableSchema } from '../schemas/remnote-schemas.js';
 import { checkVersionCompatibility } from '../version-compat.js';
 import type { Logger } from '../logger.js';
 
@@ -464,6 +465,79 @@ export const STATUS_TOOL = {
   },
 };
 
+export const READ_TABLE_TOOL = {
+  name: 'remnote_read_table',
+  description:
+    'Read an Advanced Table from RemNote by table name or Rem ID. Returns the table schema (columns with property types) and row data (cell values). Use this when you need structured tabular data. For simple tag-based queries without table structure, prefer remnote_search_by_tag.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      tableNameOrId: {
+        type: 'string',
+        description: 'Table Rem ID or tag name powering the table',
+      },
+      limit: {
+        type: 'number',
+        description: 'Maximum rows to return (1-150, default: 50)',
+      },
+      offset: {
+        type: 'number',
+        description: '0-based row offset for pagination (default: 0)',
+      },
+      propertyFilter: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Only return these property/column names (all if omitted)',
+      },
+    },
+    required: ['tableNameOrId'],
+  },
+  outputSchema: {
+    type: 'object' as const,
+    properties: {
+      tableId: { type: 'string', description: 'Rem ID of the table/tag' },
+      tableName: { type: 'string', description: 'Display name of the table' },
+      columns: {
+        type: 'array',
+        description: 'Table columns (properties)',
+        items: {
+          type: 'object',
+          properties: {
+            propertyId: { type: 'string', description: 'Property Rem ID' },
+            name: { type: 'string', description: 'Column/property name' },
+            type: {
+              type: 'string',
+              description:
+                'Property type (text, number, date, checkbox, single_select, multi_select, url, etc.)',
+            },
+          },
+          required: ['propertyId', 'name', 'type'],
+        },
+      },
+      rows: {
+        type: 'array',
+        description: 'Table rows with cell values',
+        items: {
+          type: 'object',
+          properties: {
+            remId: { type: 'string', description: 'Row Rem ID' },
+            name: { type: 'string', description: 'Row name (first column / Rem text)' },
+            values: {
+              type: 'object',
+              description: 'Cell values keyed by propertyId',
+              additionalProperties: { type: 'string' },
+            },
+          },
+          required: ['remId', 'name', 'values'],
+        },
+      },
+      totalRows: { type: 'number', description: 'Total number of rows in the table' },
+      rowsReturned: { type: 'number', description: 'Number of rows returned in this response' },
+    },
+    required: ['tableId', 'tableName', 'columns', 'rows', 'totalRows', 'rowsReturned'],
+  },
+};
+
 export const PLAYBOOK_TOOL = {
   name: 'remnote_get_playbook',
   description:
@@ -632,6 +706,7 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
               'Need connection/capability context? Call remnote_status first.',
               'Need to orient across the KB? Use remnote_search with includeContent="structured", depth=1, childLimit=500.',
               'Need to traverse a specific branch? Use remnote_read_note on a chosen remId with includeContent="structured", depth=1, childLimit=500, then recurse by child remIds.',
+              'Need tabular/structured data from an Advanced Table? Use remnote_read_table with the table name or ID. Use propertyFilter to limit columns for large tables.',
               'Need a human-readable summary? Switch to includeContent="markdown" on search/read results.',
               'Need to modify content? Check remnote_status: if acceptWriteOperations is false, stop; if using replaceContent, ensure acceptReplaceOperation is true.',
             ],
@@ -662,6 +737,12 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
 
         case 'remnote_status': {
           result = await buildStatusResult();
+          break;
+        }
+
+        case 'remnote_read_table': {
+          const args = ReadTableSchema.parse(request.params.arguments);
+          result = await wsServer.sendRequest('read_table', args);
           break;
         }
 
@@ -715,6 +796,7 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
         APPEND_JOURNAL_TOOL,
         PLAYBOOK_TOOL,
         STATUS_TOOL,
+        READ_TABLE_TOOL,
       ],
     };
   });

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -47,6 +47,28 @@ export const validAppendJournalInput = {
   timestamp: false,
 };
 
+export const validReadTableInput = {
+  tableNameOrId: 'table-rem-id-123',
+  limit: 50,
+  offset: 0,
+};
+
+export const sampleTableResult = {
+  tableId: 'table-rem-id-123',
+  tableName: 'Test Table',
+  columns: [
+    { propertyId: 'prop-1', name: 'Name', type: 'text' },
+    { propertyId: 'prop-2', name: 'Status', type: 'single_select' },
+    { propertyId: 'prop-3', name: 'Done', type: 'checkbox' },
+  ],
+  rows: [
+    { remId: 'row-1', name: 'Task 1', values: { 'prop-1': 'Task 1', 'prop-2': 'In Progress', 'prop-3': 'false' } },
+    { remId: 'row-2', name: 'Task 2', values: { 'prop-1': 'Task 2', 'prop-2': 'Done', 'prop-3': 'true' } },
+  ],
+  totalRows: 2,
+  rowsReturned: 2,
+};
+
 // Bridge message fixtures
 export const createBridgeRequest = (
   action: string,

--- a/test/helpers/fixtures.ts
+++ b/test/helpers/fixtures.ts
@@ -62,8 +62,16 @@ export const sampleTableResult = {
     { propertyId: 'prop-3', name: 'Done', type: 'checkbox' },
   ],
   rows: [
-    { remId: 'row-1', name: 'Task 1', values: { 'prop-1': 'Task 1', 'prop-2': 'In Progress', 'prop-3': 'false' } },
-    { remId: 'row-2', name: 'Task 2', values: { 'prop-1': 'Task 2', 'prop-2': 'Done', 'prop-3': 'true' } },
+    {
+      remId: 'row-1',
+      name: 'Task 1',
+      values: { 'prop-1': 'Task 1', 'prop-2': 'In Progress', 'prop-3': 'false' },
+    },
+    {
+      remId: 'row-2',
+      name: 'Task 2',
+      values: { 'prop-1': 'Task 2', 'prop-2': 'Done', 'prop-3': 'true' },
+    },
   ],
   totalRows: 2,
   rowsReturned: 2,

--- a/test/helpers/integration-config.ts
+++ b/test/helpers/integration-config.ts
@@ -1,0 +1,79 @@
+/**
+ * Integration test configuration utility.
+ *
+ * Reads configuration from the shared config file location:
+ * $HOME/.remnote-mcp-bridge/remnote-mcp-bridge.json
+ *
+ * This allows users to configure integration tests without modifying code,
+ * e.g., specifying a table remId for read_table tests.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+const CONFIG_FILE = '.remnote-mcp-bridge.json';
+
+/** Config structure for integration tests. */
+export interface IntegrationTestConfig {
+  /** Table Rem ID or tag name for read_table integration tests (MCP tool parameter: tableNameOrId) */
+  tableNameOrId?: string;
+  /** Table name for CLI read-table integration tests */
+  tableName?: string;
+}
+
+/** Root config structure matching the JSON file schema. */
+export interface RemnoteMcpBridgeConfig {
+  integrationTest?: IntegrationTestConfig;
+}
+
+/**
+ * Get the path to the config file in the user's home directory.
+ */
+export function getConfigPath(): string {
+  return path.join(os.homedir(), CONFIG_FILE);
+}
+
+/**
+ * Load the config file from the user's home directory.
+ * Returns null if the file doesn't exist or is invalid JSON.
+ */
+export function loadConfig(): RemnoteMcpBridgeConfig | null {
+  const configPath = getConfigPath();
+
+  if (!fs.existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = fs.readFileSync(configPath, 'utf-8');
+    return JSON.parse(content) as RemnoteMcpBridgeConfig;
+  } catch {
+    // File exists but couldn't be parsed
+    return null;
+  }
+}
+
+/**
+ * Get the integration test config section.
+ * Returns null if the config file doesn't exist or has no integration test section.
+ */
+export function getIntegrationTestConfig(): IntegrationTestConfig | null {
+  const config = loadConfig();
+  return config?.integrationTest ?? null;
+}
+
+/**
+ * Check if integration test config exists and has a tableNameOrId.
+ */
+export function hasTableConfig(): boolean {
+  const config = getIntegrationTestConfig();
+  return config?.tableNameOrId !== undefined && config.tableNameOrId !== '';
+}
+
+/**
+ * Get a warning message for when table config is missing.
+ */
+export function getTableConfigWarning(): string {
+  return `Integration test table not configured. Set integrationTest.tableNameOrId in ${getConfigPath()}`;
+}

--- a/test/integration/run-integration.ts
+++ b/test/integration/run-integration.ts
@@ -20,6 +20,7 @@ import { createSearchWorkflow } from './workflows/02-create-search.js';
 import { readUpdateWorkflow } from './workflows/03-read-update.js';
 import { journalWorkflow } from './workflows/04-journal.js';
 import { errorCasesWorkflow } from './workflows/05-error-cases.js';
+import { readTableWorkflow } from './workflows/06-read-table.js';
 import type { WorkflowResult, WorkflowFn, SharedState } from './types.js';
 
 const RESET = '\x1b[0m';
@@ -298,6 +299,7 @@ async function main(): Promise<void> {
     { name: 'Read & Update', fn: readUpdateWorkflow },
     { name: 'Journal', fn: journalWorkflow },
     { name: 'Error Cases', fn: errorCasesWorkflow },
+    { name: 'Read Table', fn: readTableWorkflow },
   ];
 
   try {

--- a/test/integration/workflows/06-read-table.ts
+++ b/test/integration/workflows/06-read-table.ts
@@ -1,0 +1,192 @@
+/**
+ * Workflow 06: Read Table
+ *
+ * Tests the read_table functionality by reading an Advanced Table configured
+ * via integration test config.
+ *
+ * Prerequisites:
+ * - Config file must exist at $HOME/.remnote-mcp-bridge/remnote-mcp-bridge.json
+ * - Must contain integrationTest.tableNameOrId
+ */
+
+import {
+  assertTruthy,
+  assertHasField,
+  assertIsArray,
+  assertEqual,
+} from '../assertions.js';
+import { hasTableConfig, getIntegrationTestConfig, getTableConfigWarning } from '../../helpers/integration-config.js';
+import type { WorkflowContext, WorkflowResult, SharedState, StepResult } from '../types';
+
+/** Expected structure of read_table response */
+interface ReadTableResponse {
+  columns: Array<{ name: string; propertyId: string; type: string }>;
+  rows: Array<{ name: string; remId: string; values: Record<string, string[]> }>;
+}
+
+export async function readTableWorkflow(
+  ctx: WorkflowContext,
+  _state: SharedState
+): Promise<WorkflowResult> {
+  const steps: StepResult[] = [];
+
+  // Check if table config exists - skip test if not configured
+  if (!hasTableConfig()) {
+    const warning = getTableConfigWarning();
+    steps.push({
+      label: 'Table config check',
+      passed: false,
+      durationMs: 0,
+      error: warning,
+    });
+    return {
+      name: 'Read Table',
+      steps,
+      skipped: false,
+    };
+  }
+
+  const config = getIntegrationTestConfig()!;
+  const tableNameOrId = config.tableNameOrId!;
+
+  // Step 1: Call remnote_read_table with table name or ID
+  {
+    const start = Date.now();
+    try {
+      const result = (await ctx.client.callTool('remnote_read_table', {
+        tableNameOrId,
+      })) as Record<string, unknown>;
+
+      // Verify response has columns and rows
+      assertHasField(result, 'columns', 'read_table response');
+      assertHasField(result, 'rows', 'read_table response');
+
+      const columns = result.columns as ReadTableResponse['columns'];
+      const rows = result.rows as ReadTableResponse['rows'];
+
+      assertIsArray(columns, 'columns should be an array');
+      assertIsArray(rows, 'rows should be an array');
+
+      // Columns should have name, propertyId, type fields
+      if (Array.isArray(columns) && columns.length > 0) {
+        const firstCol = columns[0] as Record<string, unknown>;
+        assertHasField(firstCol, 'name', 'column should have name');
+        assertHasField(firstCol, 'propertyId', 'column should have propertyId');
+        assertHasField(firstCol, 'type', 'column should have type');
+      }
+
+      // Rows should have name, remId, values fields
+      if (Array.isArray(rows) && rows.length > 0) {
+        const firstRow = rows[0] as Record<string, unknown>;
+        assertHasField(firstRow, 'name', 'row should have name');
+        assertHasField(firstRow, 'remId', 'row should have remId');
+        assertHasField(firstRow, 'values', 'row should have values');
+      }
+
+      steps.push({
+        label: `Read table (${columns?.length ?? 0} columns, ${rows?.length ?? 0} rows)`,
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Read table',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 2: Call remnote_read_table with limit
+  {
+    const start = Date.now();
+    try {
+      const result = (await ctx.client.callTool('remnote_read_table', {
+        tableNameOrId,
+        limit: 1,
+      })) as Record<string, unknown>;
+
+      assertHasField(result, 'rows', 'read_table with limit response');
+      const rows = result.rows as ReadTableResponse['rows'];
+      assertIsArray(rows, 'rows should be an array');
+      assertTruthy(
+        Array.isArray(rows) && rows.length <= 1,
+        'limit=1 should return at most 1 row'
+      );
+
+      steps.push({
+        label: 'Read table with limit=1',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Read table with limit=1',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 3: Call remnote_read_table with offset
+  {
+    const start = Date.now();
+    try {
+      const result = (await ctx.client.callTool('remnote_read_table', {
+        tableNameOrId,
+        offset: 1,
+      })) as Record<string, unknown>;
+
+      assertHasField(result, 'rows', 'read_table with offset response');
+      const rows = result.rows as ReadTableResponse['rows'];
+      assertIsArray(rows, 'rows should be an array');
+
+      steps.push({
+        label: 'Read table with offset=1',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Read table with offset=1',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 4: Call remnote_read_table with invalid table name (error case)
+  {
+    const start = Date.now();
+    try {
+      const result = (await ctx.client.callTool('remnote_read_table', {
+        tableNameOrId: 'invalid-table-name-xyz-12345',
+      })) as Record<string, unknown>;
+
+      // If we get here without error, check if it's an error response
+      // (depends on how the server handles invalid IDs)
+      // This step just verifies the tool doesn't crash
+      assertHasField(result, 'columns', 'read_table with invalid ID should return columns');
+      assertHasField(result, 'rows', 'read_table with invalid ID should return rows');
+
+      steps.push({
+        label: 'Read table with invalid name',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      // Error is acceptable for invalid table name
+      steps.push({
+        label: 'Read table with invalid name',
+        passed: true,
+        durationMs: Date.now() - start,
+        error: `Expected error (acceptable): ${(e as Error).message}`,
+      });
+    }
+  }
+
+  return { name: 'Read Table', steps, skipped: false };
+}

--- a/test/integration/workflows/06-read-table.ts
+++ b/test/integration/workflows/06-read-table.ts
@@ -9,13 +9,12 @@
  * - Must contain integrationTest.tableNameOrId
  */
 
+import { assertTruthy, assertHasField, assertIsArray, assertEqual } from '../assertions.js';
 import {
-  assertTruthy,
-  assertHasField,
-  assertIsArray,
-  assertEqual,
-} from '../assertions.js';
-import { hasTableConfig, getIntegrationTestConfig, getTableConfigWarning } from '../../helpers/integration-config.js';
+  hasTableConfig,
+  getIntegrationTestConfig,
+  getTableConfigWarning,
+} from '../../helpers/integration-config.js';
 import type { WorkflowContext, WorkflowResult, SharedState, StepResult } from '../types';
 
 /** Expected structure of read_table response */
@@ -110,10 +109,7 @@ export async function readTableWorkflow(
       assertHasField(result, 'rows', 'read_table with limit response');
       const rows = result.rows as ReadTableResponse['rows'];
       assertIsArray(rows, 'rows should be an array');
-      assertTruthy(
-        Array.isArray(rows) && rows.length <= 1,
-        'limit=1 should return at most 1 row'
-      );
+      assertTruthy(Array.isArray(rows) && rows.length <= 1, 'limit=1 should return at most 1 row');
 
       steps.push({
         label: 'Read table with limit=1',

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -11,6 +11,7 @@ import {
   ReadNoteSchema,
   UpdateNoteSchema,
   AppendJournalSchema,
+  ReadTableSchema,
 } from '../../src/schemas/remnote-schemas.js';
 
 describe('CreateNoteSchema', () => {
@@ -278,5 +279,70 @@ describe('AppendJournalSchema', () => {
 
   it('should reject non-boolean timestamp', () => {
     expect(() => AppendJournalSchema.parse({ content: 'Test', timestamp: 'yes' })).toThrow();
+  });
+});
+
+describe('ReadTableSchema', () => {
+  it('should validate with only required tableNameOrId field', () => {
+    const result = ReadTableSchema.parse({ tableNameOrId: 'abc123' });
+    expect(result.tableNameOrId).toBe('abc123');
+  });
+
+  it('should apply default limit of 50', () => {
+    const result = ReadTableSchema.parse({ tableNameOrId: 'abc123' });
+    expect(result.limit).toBe(50);
+  });
+
+  it('should apply default offset of 0', () => {
+    const result = ReadTableSchema.parse({ tableNameOrId: 'abc123' });
+    expect(result.offset).toBe(0);
+  });
+
+  it('should validate with explicit limit', () => {
+    const result = ReadTableSchema.parse({ tableNameOrId: 'x', limit: 100 });
+    expect(result.limit).toBe(100);
+  });
+
+  it('should reject limit less than 1', () => {
+    expect(() => ReadTableSchema.parse({ tableNameOrId: 'x', limit: 0 })).toThrow();
+  });
+
+  it('should reject limit greater than 150', () => {
+    expect(() => ReadTableSchema.parse({ tableNameOrId: 'x', limit: 151 })).toThrow();
+  });
+
+  it('should accept limit of 150', () => {
+    const result = ReadTableSchema.parse({ tableNameOrId: 'x', limit: 150 });
+    expect(result.limit).toBe(150);
+  });
+
+  it('should reject negative offset', () => {
+    expect(() => ReadTableSchema.parse({ tableNameOrId: 'x', offset: -1 })).toThrow();
+  });
+
+  it('should accept offset of 0', () => {
+    const result = ReadTableSchema.parse({ tableNameOrId: 'x', offset: 0 });
+    expect(result.offset).toBe(0);
+  });
+
+  it('should accept propertyFilter array', () => {
+    const result = ReadTableSchema.parse({
+      tableNameOrId: 'x',
+      propertyFilter: ['Status', 'Priority'],
+    });
+    expect(result.propertyFilter).toEqual(['Status', 'Priority']);
+  });
+
+  it('should accept empty propertyFilter array', () => {
+    const result = ReadTableSchema.parse({ tableNameOrId: 'x', propertyFilter: [] });
+    expect(result.propertyFilter).toEqual([]);
+  });
+
+  it('should reject missing tableNameOrId', () => {
+    expect(() => ReadTableSchema.parse({ limit: 50 })).toThrow();
+  });
+
+  it('should reject empty tableNameOrId', () => {
+    expect(() => ReadTableSchema.parse({ tableNameOrId: '' })).toThrow();
   });
 });

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -14,6 +14,7 @@ import {
   APPEND_JOURNAL_TOOL,
   PLAYBOOK_TOOL,
   STATUS_TOOL,
+  READ_TABLE_TOOL,
 } from '../../src/tools/index.js';
 import { WebSocketServer } from '../../src/websocket-server.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -25,10 +26,12 @@ import {
   validUpdateNoteInput,
   validUpdateReplaceInput,
   validAppendJournalInput,
+  validReadTableInput,
   sampleMutatingResult,
   sampleNoteResult,
   sampleSearchResults,
   sampleStatusResult,
+  sampleTableResult,
 } from '../helpers/fixtures.js';
 import { createMockLogger } from '../setup.js';
 
@@ -188,6 +191,24 @@ describe('Tool Definitions', () => {
   it('should have no required fields for PLAYBOOK_TOOL', () => {
     expect(PLAYBOOK_TOOL.inputSchema.required || []).toHaveLength(0);
   });
+
+  it('should have correct name for READ_TABLE_TOOL', () => {
+    expect(READ_TABLE_TOOL.name).toBe('remnote_read_table');
+  });
+
+  it('should have required tableNameOrId field for READ_TABLE_TOOL', () => {
+    expect(READ_TABLE_TOOL.inputSchema.required).toContain('tableNameOrId');
+  });
+
+  it('should have correct output schema for READ_TABLE_TOOL', () => {
+    const properties = READ_TABLE_TOOL.outputSchema.properties as Record<string, unknown>;
+    expect(properties.tableId).toBeDefined();
+    expect(properties.tableName).toBeDefined();
+    expect(properties.columns).toBeDefined();
+    expect(properties.rows).toBeDefined();
+    expect(properties.totalRows).toBeDefined();
+    expect(properties.rowsReturned).toBeDefined();
+  });
 });
 
 describe('Tool Registration', () => {
@@ -216,7 +237,7 @@ describe('Tool Registration', () => {
       tools: unknown[];
     };
 
-    expect(result.tools).toHaveLength(8);
+    expect(result.tools).toHaveLength(9);
   });
 
   it('should include all tool names in list', async () => {
@@ -235,6 +256,7 @@ describe('Tool Registration', () => {
     expect(names).toContain('remnote_append_journal');
     expect(names).toContain('remnote_get_playbook');
     expect(names).toContain('remnote_status');
+    expect(names).toContain('remnote_read_table');
   });
 });
 
@@ -551,6 +573,68 @@ describe('Tool Handlers - append_journal', () => {
 
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed).toEqual(sampleMutatingResult);
+  });
+});
+
+describe('Tool Handlers - read_table', () => {
+  let mockServer: MockMCPServer;
+  let mockWsServer: { sendRequest: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockServer = new MockMCPServer();
+    mockWsServer = {
+      sendRequest: vi.fn().mockResolvedValue(sampleTableResult),
+    };
+    registerAllTools(mockServer as never, mockWsServer as never, createMockLogger() as never);
+  });
+
+  it('should call wsServer.sendRequest with read_table action', async () => {
+    await mockServer.callHandler(CallToolRequestSchema, {
+      params: { name: 'remnote_read_table', arguments: validReadTableInput },
+    });
+
+    expect(mockWsServer.sendRequest).toHaveBeenCalledWith('read_table', {
+      ...validReadTableInput,
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  it('should apply default values from schema', async () => {
+    await mockServer.callHandler(CallToolRequestSchema, {
+      params: { name: 'remnote_read_table', arguments: { tableNameOrId: 'my-table' } },
+    });
+
+    expect(mockWsServer.sendRequest).toHaveBeenCalledWith('read_table', {
+      tableNameOrId: 'my-table',
+      limit: 50, // default
+      offset: 0, // default
+    });
+  });
+
+  it('should return formatted JSON result', async () => {
+    const result = (await mockServer.callHandler(CallToolRequestSchema, {
+      params: { name: 'remnote_read_table', arguments: validReadTableInput },
+    })) as { content: { type: string; text: string }[] };
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual(sampleTableResult);
+  });
+
+  it('should pass through propertyFilter', async () => {
+    await mockServer.callHandler(CallToolRequestSchema, {
+      params: {
+        name: 'remnote_read_table',
+        arguments: { tableNameOrId: 'my-table', propertyFilter: ['Name', 'Status'] },
+      },
+    });
+
+    expect(mockWsServer.sendRequest).toHaveBeenCalledWith('read_table', {
+      tableNameOrId: 'my-table',
+      limit: 50,
+      offset: 0,
+      propertyFilter: ['Name', 'Status'],
+    });
   });
 });
 


### PR DESCRIPTION
### Summary

This PR exposes the `read_table` functionality as an MCP tool through the remnote-mcp-server.

### Changes

- **`src/schemas/remnote-schemas.ts`** — Added [`ReadTableSchema`](src/schemas/remnote-schemas.ts) with Zod validation:
  - `tableNameOrId` (Table Rem ID or tag name powering the table)
  - `limit` (Maximum rows to return (1-150, default: 50))
  - `offset` (0-based row offset for pagination (default: 0))
  - `propertyFilter` (Only return these property/column names (all if omitted))

- **`src/tools/index.ts`** — Added [`READ_TABLE_TOOL`](src/tools/index.ts):
  - MCP tool definition with `tableName` input
  - Handler that calls bridge's `read_table` action
  - Returns formatted table data with columns and rows
  - Added to playbooks

- **`test/unit/schemas.test.ts`** — Added 13 schema validation tests

- **`test/unit/tools.test.ts`** — Added 7 tool tests