### PR TITLE
fix(tools): return structuredContent so strict MCP clients accept tool results

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -763,6 +763,7 @@ export function registerAllTools(server: Server, wsServer: WebSocketServer, logg
       );
 
       return {
+        structuredContent: result as { [key: string]: unknown },
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };
     } catch (error) {


### PR DESCRIPTION
## Summary

Every tool registered in `src/tools/index.ts` declares an `outputSchema`, but the shared `CallToolRequestSchema` handler only returns a `content` text block. Per the MCP spec, when a tool declares an output schema the response **MUST** include `structuredContent` matching that schema.

Strict MCP clients (recent Claude Code / Claude Desktop builds, and any client built on a current `@modelcontextprotocol/sdk`) reject every successful tool call with:

```
MCP error -32600: Tool <name> has an output schema but did not return structured content
```

In practice this means **no tool works end-to-end** with strict clients today, even though the WebSocket bridge is happily returning the correct payload. I hit this on Claude Desktop 0.x using `mcp-remote` against a local `remnote-mcp-server@0.11.0`, on every single tool (`remnote_search`, `remnote_status`, `remnote_get_playbook`, …).

## Fix

Surface the same `result` object (already serialized into the `text` content block) as `structuredContent`. Because the existing text content was already `JSON.stringify(result, …)`, the payload is structurally identical to what every declared `outputSchema` describes — no schema changes needed.

```diff
       return {
+        structuredContent: result as { [key: string]: unknown },
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };
```

The error branch is intentionally unchanged: `isError: true` responses are not validated against `outputSchema`.

The cast is the minimum needed to satisfy the MCP SDK's `CallToolResult.structuredContent` type (`{ [key: string]: unknown }`); `result` is implicitly `any` in the surrounding `let result;`, and at runtime every code path assigns it from `wsServer.sendRequest(...)` (or, for `remnote_get_playbook`, an inline object literal), all of which are JSON objects matching the declared schemas.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test` — 274/276 pass; the 2 pre-existing failures are Windows-only and unrelated (`logger.test.ts` "invalid path" assertion + `run-status-check.sh` Unix exec-bit check)
- [x] Manual end-to-end against Claude Desktop via `mcp-remote http://127.0.0.1:3001/mcp --allow-http`:
  - Before patch: every tool call returns `MCP error -32600: ... did not return structured content`
  - After patch: `remnote_search`, `remnote_get_playbook`, `remnote_status`, etc. all return correctly

## Notes

I didn't touch `dist/`. If you publish a new patch version after merging, please bump and republish to npm so users don't have to manually patch their installs.