### PR TITLE
Feature/search in rem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Add `parentRemId` to `remnote_search` input schema and `--parent-id` option to `remnote-cli search` to support scoping search within a Rem's subtree.
 - Add `remnote_set_document_status` for dry-run-first document status updates that preserve Rem IDs, hierarchy, tags,
   and concept/card status.
 - Add `remnote-cli set-document-status` for dry-run-first document status updates on existing Rems.
@@ -40,6 +41,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Update `remnote_search` tools reference, CLI command `search` reference, and agent skill documentation to include advanced scoped search with parent ID and document cursor limitations.
 - Update `remnote_get_playbook`, tool docs, and the MCP smoke prompt for document-status workflows.
 - Update the bundled `remnote-cli` skill guidance for document-root creation and document-status workflows.
 - Update `AGENTS.md` contract maps for the current discovery API tool and CLI surface, including

--- a/docs/guides/remnote-cli-command-reference.md
+++ b/docs/guides/remnote-cli-command-reference.md
@@ -126,7 +126,6 @@ Shared options for `search` and `search-by-tag`:
 | `--content-mode <mode>`    | `none`  | `none`, `markdown`, or `structured`  |
 | `--view <view>`            | default | `compact`, `standard`, or `full`     |
 | `--ancestor-depth <n>`     | `0`     | Parent Rems to include, parent-first |
-| `--parent-id <id>`         | none    | Parent Rem ID to scope search        |
 | `--depth <n>`              | `1`     | Child depth for rendered content     |
 | `--child-limit <n>`        | `20`    | Max children per hierarchy level     |
 | `--max-content-length <n>` | `3000`  | Max rendered content character count |
@@ -135,7 +134,8 @@ Shared options for `search` and `search-by-tag`:
 
 | Option              | Default | Description                                      |
 | ------------------- | ------- | ------------------------------------------------ |
-| `--cursor <cursor>` | n/a     | Opaque cursor from a previous `search` response |
+| `--parent-id <id>`  | none    | Parent Rem ID to scope search within its subtree |
+| `--cursor <cursor>` | n/a     | Opaque cursor from a previous `search` response  |
 
 Behavior rules:
 
@@ -148,7 +148,7 @@ Behavior rules:
 - `--depth`, `--child-limit`, and `--max-content-length` are most relevant when content rendering is enabled.
 - `tags` is optional and present when the matched Rem has readable tag identity metadata. JSON output preserves
   `{ tagRemId, name }` objects.
-- `--cursor` is bound to the specific search `query` and `--parent-id`; the parameter was mandatory to include with `--cursor` flag; it cannot be reused across different queries or parameters.
+- `--cursor` is bound to the specific search `query` and `--parent-id`. A cursor must be reused with the exact same query and parameters, and cannot be reused across different queries or scopes.
 
 Examples:
 

--- a/docs/guides/remnote-cli-command-reference.md
+++ b/docs/guides/remnote-cli-command-reference.md
@@ -126,6 +126,7 @@ Shared options for `search` and `search-by-tag`:
 | `--content-mode <mode>`    | `none`  | `none`, `markdown`, or `structured`  |
 | `--view <view>`            | default | `compact`, `standard`, or `full`     |
 | `--ancestor-depth <n>`     | `0`     | Parent Rems to include, parent-first |
+| `--parent-id <id>`         | none    | Parent Rem ID to scope search        |
 | `--depth <n>`              | `1`     | Child depth for rendered content     |
 | `--child-limit <n>`        | `20`    | Max children per hierarchy level     |
 | `--max-content-length <n>` | `3000`  | Max rendered content character count |
@@ -147,6 +148,7 @@ Behavior rules:
 - `--depth`, `--child-limit`, and `--max-content-length` are most relevant when content rendering is enabled.
 - `tags` is optional and present when the matched Rem has readable tag identity metadata. JSON output preserves
   `{ tagRemId, name }` objects.
+- `--cursor` is bound to the specific search `query` and `--parent-id`; the parameter was mandatory to include with `--cursor` flag; it cannot be reused across different queries or parameters.
 
 Examples:
 
@@ -154,6 +156,8 @@ Examples:
 remnote-cli search "meeting"
 remnote-cli search "weekly" --limit 10 --content-mode structured --depth 2 --child-limit 10 --text
 remnote-cli search "weekly" --limit 10 --cursor "search:v1:..."
+remnote-cli search "meeting" --limit 10 --parent-id <parent-rem-id>
+remnote-cli search "meeting" --limit 10 --parent-id <parent-rem-id> --cursor "search:v1:..."
 ```
 
 ## search-by-tag

--- a/docs/guides/tools-reference.md
+++ b/docs/guides/tools-reference.md
@@ -141,6 +141,7 @@ Search your RemNote knowledge base with full-text search.
 | `view` | string | No | Output detail level: `compact`, `standard` (default), or `full` |
 | `ancestorDepth` | number | No | Number of parent Rems to include, direct parent first |
 | `depth` | number | No | Max child depth for rendered content (0-10, default: 1) |
+| `parentRemId` | string | No | Scope search within this Rem's subtree |
 
 ### Usage
 
@@ -223,6 +224,7 @@ Returns matching notes plus paging metadata:
 ### Tips
 
 - Use specific terms for better results
+- Use `parentRemId` to scope your search within a specific Rem's subtree (e.g. search within a specific folder or document)
 - Increase `limit` for comprehensive searches
 - Use `contentMode: "none"` (default) for faster searches when you only need titles
 - Use `contentMode: "markdown"` when you need rendered child context

--- a/mcpb/remnote-local/server/fallback-tools.generated.js
+++ b/mcpb/remnote-local/server/fallback-tools.generated.js
@@ -47,6 +47,11 @@ export const FALLBACK_TOOLS = [
           type: 'string',
           description: 'Search query text',
         },
+        parentRemId: {
+          type: 'string',
+          description:
+            "Optional. Scope the search to within this Rem's subtree. The Rem itself is excluded from results.",
+        },
         limit: {
           type: 'number',
           description: 'Maximum results (1-150, default: 50)',

--- a/skills/remnote/SKILL.md
+++ b/skills/remnote/SKILL.md
@@ -119,7 +119,7 @@ If any precondition is missing, stop and fix setup first.
 
 ### Read-Only Operations (default)
 
-- Search notes: `remnote-cli search "query"`
+- Search notes: `remnote-cli search "query"` (use `--parent-id <parent-rem-id>` to scope search within a Rem's subtree)
 - Search by exact tag Rem ID: `remnote-cli search-by-tag --tag-id <tag-rem-id>`
 - Read note by Rem ID: `remnote-cli read <rem-id>`
 - Read Advanced Table by title or Rem ID:

--- a/src/remnote-cli/commands/search.ts
+++ b/src/remnote-cli/commands/search.ts
@@ -119,6 +119,7 @@ export function registerSearchCommand(program: Command): void {
     program.command('search <query>').description('Search for notes in RemNote')
   )
     .option('--cursor <cursor>', 'Opaque cursor returned by a previous search page')
+    .option('--parent-id <remId>', "Optional. Scope search to within this Rem's subtree")
     .action(async (query: string, opts) => {
       const globalOpts = program.opts();
       const format: OutputFormat = globalOpts.text ? 'text' : 'json';
@@ -130,6 +131,7 @@ export function registerSearchCommand(program: Command): void {
           limit: parseInt(opts.limit, 10),
         };
         if (opts.cursor) payload.cursor = opts.cursor;
+        if (opts.parentId) payload.parentRemId = opts.parentId;
         applySearchOptions(payload, opts);
 
         const result = await client.execute('search', payload);

--- a/src/schemas/remnote-schemas.ts
+++ b/src/schemas/remnote-schemas.ts
@@ -66,6 +66,12 @@ export const CreateNoteSchema = z
 export const SearchSchema = z
   .object({
     query: z.string().describe('Search query text'),
+    parentRemId: z
+      .string()
+      .optional()
+      .describe(
+        "Optional. Scope the search to within this Rem's subtree. The Rem itself is excluded from results."
+      ),
     limit: z.number().int().min(1).max(150).default(50).describe('Maximum results'),
     cursor: z
       .string()

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -158,6 +158,11 @@ export const SEARCH_TOOL = {
     type: 'object' as const,
     properties: {
       query: { type: 'string', description: 'Search query text' },
+      parentRemId: {
+        type: 'string',
+        description:
+          "Optional. Scope the search to within this Rem's subtree. The Rem itself is excluded from results.",
+      },
       limit: { type: 'number', description: 'Maximum results (1-150, default: 50)' },
       cursor: {
         type: 'string',

--- a/test/integration/cli/workflows/03-create-search.ts
+++ b/test/integration/cli/workflows/03-create-search.ts
@@ -495,7 +495,59 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 7: Search pages through cursor results
+  // Step 7: Search with parent-id scopes search successfully
+  {
+    const start = Date.now();
+    try {
+      const scopedResult = (await ctx.cli.runExpectSuccess([
+        'search',
+        simpleSearchToken,
+        '--parent-id',
+        state.integrationParentRemId,
+        '--limit',
+        '20',
+      ])) as Record<string, unknown>;
+      assertHasField(scopedResult, 'results', 'scoped search results');
+      assertIsArray(scopedResult.results, 'scoped search results array');
+      const scopedResults = scopedResult.results as Array<Record<string, unknown>>;
+      const foundInParent = scopedResults.some(
+        (r) => typeof r.title === 'string' && r.title.includes(simpleSearchToken)
+      );
+      assertTruthy(foundInParent, 'scoped search under correct parent should find simple note');
+
+      assertTruthy(typeof state.noteBId === 'string', 'rich note remId should be recorded');
+      const nonScopedResult = (await ctx.cli.runExpectSuccess([
+        'search',
+        simpleSearchToken,
+        '--parent-id',
+        state.noteBId,
+        '--limit',
+        '20',
+      ])) as Record<string, unknown>;
+      assertHasField(nonScopedResult, 'results', 'non-scoped search results');
+      assertIsArray(nonScopedResult.results, 'non-scoped search results array');
+      const nonScopedResults = nonScopedResult.results as Array<Record<string, unknown>>;
+      const foundInDummy = nonScopedResults.some(
+        (r) => typeof r.title === 'string' && r.title.includes(simpleSearchToken)
+      );
+      assertTruthy(!foundInDummy, 'scoped search under unrelated parent should NOT find simple note');
+
+      steps.push({
+        label: 'Search with parent-id scopes search successfully via CLI',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Search with parent-id scopes search successfully via CLI',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 8: Search pages through cursor results
   {
     const start = Date.now();
     try {
@@ -503,6 +555,8 @@ export async function createSearchWorkflow(
       const firstPage = (await ctx.cli.runExpectSuccess([
         'search',
         pagingSearchToken,
+        '--parent-id',
+        state.integrationParentRemId,
         '--limit',
         '2',
         '--content-mode',
@@ -528,6 +582,8 @@ export async function createSearchWorkflow(
         const nextPage = (await ctx.cli.runExpectSuccess([
           'search',
           pagingSearchToken,
+          '--parent-id',
+          state.integrationParentRemId,
           '--limit',
           '2',
           '--cursor',
@@ -573,7 +629,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 8: Search-by-tag pages through cursor results
+  // Step 9: Search-by-tag pages through cursor results
   {
     const start = Date.now();
     try {
@@ -660,7 +716,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 9-11: Search with contentMode modes
+  // Step 10-12: Search with contentMode modes
   for (const mode of ['markdown', 'structured', 'none'] as const) {
     const start = Date.now();
     const label = `Search contentMode=${mode} returns expected shape`;
@@ -706,7 +762,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 12: Root-only markdown tree tag does not bleed to descendants
+  // Step 13: Root-only markdown tree tag does not bleed to descendants
   {
     const start = Date.now();
     let debugResults: Array<Record<string, unknown>> | null = null;
@@ -760,7 +816,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 13-15: Search by exact tag Rem ID with contentMode modes
+  // Step 14: Resolve expected search-by-tag ancestor target
   let expectedTagTarget: ExpectedTagTarget | undefined;
   {
     const start = Date.now();
@@ -781,6 +837,8 @@ export async function createSearchWorkflow(
       });
     }
   }
+
+  // Step 15-17: Search by exact tag Rem ID with contentMode modes
 
   for (const mode of ['markdown', 'structured', 'none'] as const) {
     const start = Date.now();

--- a/test/integration/workflows/02-create-search.ts
+++ b/test/integration/workflows/02-create-search.ts
@@ -448,13 +448,60 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 7: Search pages through cursor results
+  // Step 7: Search with parentRemId scopes search successfully
+  {
+    const start = Date.now();
+    try {
+      const scopedResult = await ctx.client.callTool('remnote_search', {
+        query: simpleSearchToken,
+        parentRemId: state.integrationParentRemId,
+        limit: 20,
+      });
+      assertHasField(scopedResult, 'results', 'scoped search results');
+      assertIsArray(scopedResult.results, 'scoped search results array');
+      const scopedResults = scopedResult.results as Array<Record<string, unknown>>;
+      const foundInParent = scopedResults.some(
+        (r) => typeof r.title === 'string' && r.title.includes(simpleSearchToken)
+      );
+      assertTruthy(foundInParent, 'scoped search under correct parent should find simple note');
+
+      assertTruthy(typeof state.noteBId === 'string', 'rich note remId should be recorded');
+      const nonScopedResult = await ctx.client.callTool('remnote_search', {
+        query: simpleSearchToken,
+        parentRemId: state.noteBId,
+        limit: 20,
+      });
+      assertHasField(nonScopedResult, 'results', 'non-scoped search results');
+      assertIsArray(nonScopedResult.results, 'non-scoped search results array');
+      const nonScopedResults = nonScopedResult.results as Array<Record<string, unknown>>;
+      const foundInDummy = nonScopedResults.some(
+        (r) => typeof r.title === 'string' && r.title.includes(simpleSearchToken)
+      );
+      assertTruthy(!foundInDummy, 'scoped search under unrelated parent should NOT find simple note');
+
+      steps.push({
+        label: 'Search with parentRemId scopes search successfully',
+        passed: true,
+        durationMs: Date.now() - start,
+      });
+    } catch (e) {
+      steps.push({
+        label: 'Search with parentRemId scopes search successfully',
+        passed: false,
+        durationMs: Date.now() - start,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  // Step 8: Search pages through cursor results
   {
     const start = Date.now();
     try {
       assertEqual(pagingNoteIds.length, 5, 'paging fixture note count');
       const firstPage = await ctx.client.callTool('remnote_search', {
         query: pagingSearchToken,
+        parentRemId: state.integrationParentRemId,
         limit: 2,
         contentMode: 'none',
       });
@@ -477,6 +524,7 @@ export async function createSearchWorkflow(
       for (let page = 2; page <= 4 && cursor; page += 1) {
         const nextPage = await ctx.client.callTool('remnote_search', {
           query: pagingSearchToken,
+          parentRemId: state.integrationParentRemId,
           limit: 2,
           cursor,
           contentMode: 'none',
@@ -519,7 +567,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 8: Search by tag pages through cursor results
+  // Step 9: Search by tag pages through cursor results
   {
     const start = Date.now();
     try {
@@ -594,7 +642,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 9-11: Search with contentMode modes
+  // Step 10-12: Search with contentMode modes
   for (const mode of ['markdown', 'structured', 'none'] as const) {
     const start = Date.now();
     const label = `Search contentMode=${mode} returns expected shape`;
@@ -638,7 +686,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 12: Search finds markdown tree root
+  // Step 13: Search finds markdown tree root
   {
     const start = Date.now();
     let debugResults: Array<Record<string, unknown>> | null = null;
@@ -675,7 +723,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 13: Root-only markdown tree tag does not bleed to descendants
+  // Step 14: Root-only markdown tree tag does not bleed to descendants
   {
     const start = Date.now();
     let debugResults: Array<Record<string, unknown>> | null = null;
@@ -725,7 +773,7 @@ export async function createSearchWorkflow(
     }
   }
 
-  // Step 14-16: Search by exact tag Rem ID with contentMode modes
+  // Step 15: Resolve expected search-by-tag ancestor target
   let expectedTagTarget: ExpectedTagTarget | undefined;
   {
     const start = Date.now();
@@ -746,6 +794,8 @@ export async function createSearchWorkflow(
       });
     }
   }
+
+  // Step 16-18: Search by exact tag Rem ID with contentMode modes
 
   for (const mode of ['markdown', 'structured', 'none'] as const) {
     const start = Date.now();

--- a/test/unit/remnote-cli/command-action-mapping.test.ts
+++ b/test/unit/remnote-cli/command-action-mapping.test.ts
@@ -156,6 +156,21 @@ describe('command bridge action mapping', () => {
     executeSpy.mockRestore();
   });
 
+  it('passes through search parent-id option', async () => {
+    const executeSpy = await runCommand([
+      'search',
+      'ml',
+      '--parent-id',
+      'parentRemId123',
+    ]);
+    expect(executeSpy).toHaveBeenCalledWith('search', {
+      query: 'ml',
+      limit: 50,
+      parentRemId: 'parentRemId123',
+    });
+    executeSpy.mockRestore();
+  });
+
   it('passes through structured search content mode', async () => {
     const executeSpy = await runCommand(['search', 'folders', '--content-mode', 'structured']);
     expect(executeSpy).toHaveBeenCalledWith('search', {

--- a/test/unit/schemas.test.ts
+++ b/test/unit/schemas.test.ts
@@ -93,6 +93,11 @@ describe('SearchSchema', () => {
     expect(result.cursor).toBe('search:v1:id:50:hash');
   });
 
+  it('should validate with parentRemId', () => {
+    const result = SearchSchema.parse({ query: 'test', parentRemId: 'some-parent-rem-id' });
+    expect(result.parentRemId).toBe('some-parent-rem-id');
+  });
+
   it('should validate with contentMode markdown', () => {
     const result = SearchSchema.parse({ query: 'test', contentMode: 'markdown' });
     expect(result.contentMode).toBe('markdown');

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -610,6 +610,27 @@ describe('Tool Handlers - search', () => {
       view: 'standard',
     });
   });
+
+  it('should pass through parentRemId', async () => {
+    await mockServer.callHandler(CallToolRequestSchema, {
+      params: {
+        name: 'remnote_search',
+        arguments: { query: 'test', parentRemId: 'some-parent-rem-id' },
+      },
+    });
+
+    expect(mockWsServer.sendRequest).toHaveBeenCalledWith('search', {
+      query: 'test',
+      parentRemId: 'some-parent-rem-id',
+      limit: 50,
+      contentMode: 'none',
+      depth: 1,
+      childLimit: 20,
+      maxContentLength: 3000,
+      ancestorDepth: 0,
+      view: 'standard',
+    });
+  });
 });
 
 describe('Tool Handlers - search_by_tag', () => {


### PR DESCRIPTION
## Summary

Thank you for your work and continued update. When developing personal projects, I frequently ran into situations where the global search returned massive, irrelevant chunks of data. This wasted precious LLM context window space and obscured the exact topics I wanted to target. To address this, I added a **scoped search feature** utilizing a parent Rem ID (`parentRemId` / `--parent-id`).

### How Scoped Search is Achieved within Bridge:

1. **Bypassing the Broken SDK Parameter**:
   The RemNote Plugin SDK originally provides a `searchContextRemId` parameter in `plugin.search.search(text, searchContextRemId)`. However, during development and testing, we discovered that this parameter only excludes the context Rem itself from the database-level search results, without actually filtering search hits to its subtree.
2. **Manual Subtree Filtering**:
   To guarantee strict subtree scoping, the Bridge now performs manual subtree verification. We introduced a private helper `isDescendant(rem, ancestorId, relationCache)` that recursively traverses up the parent chain of each search hit to confirm whether it belongs to the target parent Rem's subtree.
3. **Performance Optimization via Relation Cache**:
   Traversing parent chains for up to 1000 search result hits dynamically via SDK IPC (`getParentRem()`) would generate huge asynchronous overhead. To mitigate this, we introduced a transient `relationCache: Map<string, boolean>` to cache resolved parent-descendant relationships. This limits IPC roundtrips to only unresolved path segments, keeping execution within milliseconds.
4. **Cursor and Pagination Consistency**:
   Cursors are bound to the specific search context. The `parentRemId` has been integrated into the `queryHash` (derived as `query + '\0' + parentRemId`). If a consumer attempts to reuse a cursor while switching parent scopes, the hash validation will reject the cursor to prevent dirty pagination and return reliable results.

---

This PR addresses the following areas of documentation, testing, and alignment:

1. **Updated Search & Cursor Documentation**: Added descriptions and examples for advanced search scoping (`parentRemId` / `--parent-id`) and explicitly documented `cursor` limitations (i.e., cursors are bound to their specific queries, parent parameters, and result modes, and are not interchangeable).
2. **Aligned Integration Test Step Comments**: Re-numbered and aligned the step comments in the integration workflows (`02-create-search.ts` and `03-create-search.ts`) with the actual steps pushed to the test runner. This resolves the non-integer index (e.g. `Step 6.5`) and properly accounts for the unindexed `Resolve expected search-by-tag ancestor target` step, restoring sequential integrity.

## Checklist

- [x] updated relevant docs.
- [x] updated tests for the changed behavior.
- [x] extended integration coverage if the shared external surface changed.
- [x] updated `CHANGELOG.md`.
- [x] kept bridge/server/CLI parity where required and linked related PRs.
