### PR TITLE
fix: allow structured leaf nodes without children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Reject empty `parentRemId` values for `remnote_search` instead of treating them as unscoped search.
+- Mark structured content node `children` arrays optional in `remnote_search` and `remnote_read_note` output schemas,
+  matching bridge responses that omit `children` for leaf nodes.
 
 ## [0.16.0] - 2026-06-05
 

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -332,11 +332,12 @@ export const SEARCH_TOOL = {
                   },
                   children: {
                     type: 'array',
-                    description: 'Nested child nodes (same shape recursively)',
+                    description:
+                      'Nested child nodes (same shape recursively; omitted for leaf nodes)',
                     items: { type: 'object' },
                   },
                 },
-                required: ['remId', 'title', 'headline', 'remType', 'children'],
+                required: ['remId', 'title', 'headline', 'remType'],
               },
             },
             contentProperties: {
@@ -590,11 +591,11 @@ export const READ_NOTE_TOOL = {
             },
             children: {
               type: 'array',
-              description: 'Nested child nodes (same shape recursively)',
+              description: 'Nested child nodes (same shape recursively; omitted for leaf nodes)',
               items: { type: 'object' },
             },
           },
-          required: ['remId', 'title', 'headline', 'remType', 'children'],
+          required: ['remId', 'title', 'headline', 'remType'],
         },
       },
       contentProperties: {

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -166,6 +166,31 @@ describe('Tool Definitions', () => {
     expect(searchResultProps.contentStructured).toBeDefined();
   });
 
+  it('should advertise structured child nodes with optional children arrays', () => {
+    const searchResultProps = ((
+      SEARCH_TOOL.outputSchema.properties.results as {
+        items?: { properties?: Record<string, unknown> };
+      }
+    ).items?.properties ?? {}) as Record<string, unknown>;
+    const searchChildSchema = (
+      searchResultProps.contentStructured as {
+        items?: { properties?: Record<string, unknown>; required?: string[] };
+      }
+    ).items;
+    const readProps = (READ_NOTE_TOOL.outputSchema.properties ?? {}) as Record<string, unknown>;
+    const readChildSchema = (
+      readProps.contentStructured as {
+        items?: { properties?: Record<string, unknown>; required?: string[] };
+      }
+    ).items;
+
+    for (const schema of [searchChildSchema, readChildSchema]) {
+      expect(schema?.properties).toHaveProperty('children');
+      expect(schema?.required).toEqual(['remId', 'title', 'headline', 'remType']);
+      expect(schema?.required).not.toContain('children');
+    }
+  });
+
   it('should advertise cursor paging for SEARCH_TOOL and SEARCH_BY_TAG_TOOL', () => {
     const outputProps = SEARCH_TOOL.outputSchema.properties as Record<string, unknown>;
     const searchByTagOutputProps = SEARCH_BY_TAG_TOOL.outputSchema.properties as Record<


### PR DESCRIPTION
## What changed

Mark the `children` array optional for structured content nodes in the `remnote_search` and `remnote_read_note` output schemas. The property remains supported for non-leaf nodes.

## Why

The RemNote bridge intentionally omits `children` for leaf nodes, but the MCP server output schema required it. Strict MCP clients therefore rejected otherwise valid large structured responses with a schema error.

## Impact

- Leaf nodes without `children` now validate correctly.
- Nested nodes may still include `children`; recursive structured output is unchanged.
- Markdown output, input schemas, and RemNote write behavior are unaffected.
- Tools inheriting the search result schema receive the corrected contract.

## Validation

- Full unit suite: 554 tests passed
- TypeScript typecheck passed
- Lint passed
- Formatting check passed
- Production build passed
- MCPB generated-metadata check passed
- Live RemNote server and bridge reconnected on v0.17.0, and a fresh Codex task advertised `children?` in the structured output schema